### PR TITLE
agent(github-delivery): enforce issue status updates (#6)

### DIFF
--- a/.codex/skills/firefly-github-delivery/SKILL.md
+++ b/.codex/skills/firefly-github-delivery/SKILL.md
@@ -23,11 +23,24 @@ Use local `gh` commands as a helper or fallback when terminal GitHub workflow is
 - Start by reading the issue carefully and restating its goal, scope, acceptance criteria, constraints, and useful context.
 - Treat ambiguity in the issue as a blocker to clarify, not an invitation to invent scope.
 - Read the relevant repo docs for the touched area before editing.
+- Before substantive implementation work begins, update the source GitHub issue with a short status comment that says Codex has picked it up in `co-op` mode, names the working branch, and marks the issue status as `in progress`.
 - Use `firefly-planning` when the issue needs refinement, sequencing, or issue breakdown before implementation.
 - Use `firefly-frontend-delivery` for frontend implementation work.
 - Use `firefly-backend-delivery` for backend implementation work.
 - Keep the implementation scoped to the issue acceptance criteria and constraints.
 - Keep one GitHub issue mapped to one focused branch and one reviewable PR.
+- If the work becomes blocked, add a follow-up issue comment that marks the status as `blocked` and explains the blocker clearly.
+- Before handing work back for review, add a follow-up issue comment that marks the status as `ready for review` and summarizes validation, assumptions, and any remaining risks.
+
+## Issue Status Rules
+
+- Treat issue comments as the required source of visible status during the current manual `co-op` workflow.
+- Required issue status transitions are:
+  - `in progress` when Codex starts active work on the issue
+  - `blocked` when Codex cannot continue without input or an external dependency
+  - `ready for review` when implementation and validation are complete
+- When the repository label set supports it, mirror the same state with labels such as `blocked` or `ready-for-review`, but do not skip the required status comment.
+- Keep status comments short, specific, and human-readable so the issue timeline explains what happened without opening the branch or PR.
 
 ## Naming Rules
 
@@ -47,6 +60,7 @@ Use local `gh` commands as a helper or fallback when terminal GitHub workflow is
 - Implement the smallest change that satisfies the issue.
 - Add or update tests when appropriate for the touched behavior.
 - Run the relevant checks that exist.
+- Keep the issue status comment aligned with the current state of the work as it changes.
 - Rebase the issue branch onto the latest target branch before opening the PR when the workflow expects a clean linear history.
 - Leave final review and squash merge to the repository owner.
 

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -10,6 +10,9 @@ body:
         Issue title convention:
         - Use a short descriptive phrase
         - Do not prefix the issue title with feat, fix, docs, or similar change types
+
+        Codex workflow note:
+        - When Codex picks up this issue in `co-op` mode, it should post issue status comments such as `in progress`, `blocked`, and `ready for review`
   - type: textarea
     id: goal
     attributes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,11 @@ When Codex works in this repo:
 - Treat the GitHub issue as the source of truth for the requested change when the task comes from GitHub.
 - Expect implementation issues to use the `task` issue template with `Goal`, `Scope`, `Acceptance Criteria`, `Constraints`, and optional `Context`.
 - Stop and surface ambiguity when the issue goal, scope, or constraints are not clear enough to implement safely.
+- Update the source GitHub issue with visible status comments during issue-driven work:
+  - mark it `in progress` when work starts
+  - mark it `blocked` if progress stops on an unresolved dependency or clarification
+  - mark it `ready for review` when implementation and validation are complete
+- Treat issue comments as the required status signal in the current manual workflow, and mirror labels only when the repository label set supports them.
 - Use `firefly-github-delivery` as the orchestration skill for issue-driven work.
 - Use `firefly-planning` when the issue needs refinement, decomposition, or sequencing before coding.
 - Use `firefly-frontend-delivery` or `firefly-backend-delivery` for area-specific implementation guidance once the touched area is clear.

--- a/docs/github-delivery/manual-codex-flow.md
+++ b/docs/github-delivery/manual-codex-flow.md
@@ -31,10 +31,13 @@ It can be revisited later after the co-op flow is stable.
 3. On the Mac server, start from a clean checkout of the repository.
 4. Run a Codex command that:
    - reads the issue details
+   - posts an issue status update when work begins
    - creates a focused branch
    - implements only the requested scope
    - runs relevant checks
+   - posts a blocked status comment if the work cannot continue
    - rebases onto the latest target branch before PR creation
+   - posts a ready-for-review status comment when the work is complete
    - prepares a reviewable pull request
 5. Review the branch and PR output yourself before merge.
 
@@ -44,6 +47,7 @@ The exact trigger command can evolve, but it should always preserve the same con
 - point Codex at one issue only
 - require it to treat the issue as the source of truth
 - require it to read `AGENTS.md` and the relevant docs first
+- require it to post visible issue status comments as work progresses
 - keep scope limited to the issue
 - require branch naming and PR title formatting to match repo conventions
 - require the PR body to include `Closes #<issue-number>`
@@ -59,10 +63,13 @@ When you build the manual command, the prompt should tell Codex to:
 - fetch and summarize the target issue
 - restate the issue goal, scope, acceptance criteria, constraints, and context
 - create a branch named for the issue
+- mark the issue `in progress` with a short status comment when work starts
 - implement the smallest change that satisfies the issue
 - add or update tests when appropriate
 - run relevant checks
+- mark the issue `blocked` with a short status comment if work cannot continue
 - rebase onto the latest target branch before opening the PR
+- mark the issue `ready for review` with a short status comment when implementation and validation are complete
 - use the repo PR title convention
 - add `Closes #<issue-number>` to the PR body
 - prepare the change for human review

--- a/docs/github-delivery/overview.md
+++ b/docs/github-delivery/overview.md
@@ -11,6 +11,7 @@ The first goal is to prove that a small, focused issue can be created in GitHub,
 - You create the issue yourself in GitHub.
 - You use the issue as the source of truth and work with Codex in `co-op` mode.
 - You manually run a command on the Mac server to let Codex pull the issue context and begin work.
+- Codex updates the issue timeline with visible status comments such as `in progress`, `blocked`, and `ready for review` while the work moves through the manual flow.
 - Codex creates a focused branch, implements the change, runs the relevant checks, and prepares a PR.
 - You perform the final human review before merge.
 

--- a/docs/github-delivery/templates-and-management.md
+++ b/docs/github-delivery/templates-and-management.md
@@ -59,17 +59,25 @@ Recommended meaning:
 - `blocked`: Codex or the maintainer found an unresolved dependency
 - `ready-for-review`: implementation is complete and awaiting your final review
 
-You do not need all of these on day one.
-For the current manual flow, `task`, `codex`, and `co-op` are enough.
+Labels are helpful, but they are not enough on their own because they do not explain why the state changed.
+For the current manual flow, Codex should always post issue status comments as the required visible status signal.
+When the label set exists, labels can mirror the same state for quicker filtering.
+
+Recommended status comments:
+- `in progress` when Codex picks up the issue and starts active work
+- `blocked` when Codex cannot continue without clarification or an external dependency
+- `ready for review` when implementation and validation are complete
 
 ## Suggested Issue Lifecycle
 
 1. Create the issue with the `task` template.
 2. Treat it as `co-op`.
 3. Add `codex` only when you want Codex involved.
-4. Run the manual Codex command on the Mac server for `co-op` issues during the trial phase.
-5. Move the resulting PR into review.
-6. Use `ready-for-review` when Codex has finished and the final decision is yours.
+4. When Codex starts the issue, it adds an `in progress` status comment to the issue.
+5. Run the manual Codex command on the Mac server for `co-op` issues during the trial phase.
+6. If Codex gets stuck, it adds a `blocked` status comment to the issue.
+7. Move the resulting PR into review.
+8. When Codex finishes, it adds a `ready for review` status comment to the issue and, when available, applies or keeps the `ready-for-review` label for your queue.
 
 ## Pull Request Template Direction
 


### PR DESCRIPTION
Closes #6

## Summary
- require issue-driven Codex work to post visible status comments when work starts, gets blocked, and is ready for review
- align the GitHub delivery skill, AGENTS guidance, manual workflow docs, and task issue template around that status lifecycle
- keep labels optional mirrors of status rather than the only source of issue state

## Why
- picked-up issues currently do not show clear status, which makes the co-op workflow harder to manage from the issue timeline
- status comments make progress visible even when the repository has not set up a dedicated label set yet

## Validation
- ran `git diff --check`
- posted `in progress` and `ready for review` status comments on issue `#6` while performing the work

## Assumptions
- issue comments are the required status signal for the current manual co-op workflow
- labels such as `blocked` and `ready-for-review` may be added later and can mirror comment-based status when available

## Risks
- this change enforces the workflow through repository instructions and templates, not through an automated GitHub Action or bot check
- compliance still depends on the active Codex workflow following the updated repository guidance