### PR TITLE
chore(ci): rename workflow files (#11)

### DIFF
--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -1,4 +1,4 @@
-name: Release Backend
+name: CD API
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
       - "services/api/**"
       - "infra/docker/**"
       - "infra/deploy/**"
-      - ".github/workflows/release-backend.yml"
+      - ".github/workflows/cd-api.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/cd-web.yml
+++ b/.github/workflows/cd-web.yml
@@ -1,4 +1,4 @@
-name: Deploy Frontend To Cloudflare Pages
+name: CD Web
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
       - dev
     paths:
       - "apps/web/**"
-      - ".github/workflows/deploy-frontend-pages.yml"
+      - ".github/workflows/cd-web.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Future CI
+name: CI
 
 on:
   pull_request:


### PR DESCRIPTION
Closes #11

## Summary
- rename the GitHub Actions workflow display names to `CI`, `CD API`, and `CD Web`
- rename the backend and frontend deploy workflow files to match the clearer CD naming
- update workflow path triggers to reference the new filenames

## Why
- the current CI/CD workflow names are less clear than the intended short labels in the issue
- aligning filenames and workflow names makes the Actions list easier to scan and maintain

## Validation
- parsed all workflow YAML files locally with Ruby `YAML.load_file`
- checked for stale references to the previous workflow names and filenames

## Assumptions
- left `Repo Hygiene` unchanged because issue #11 only called for clearer CI/CD workflow naming

## Risks
- any external links or bookmarks to the old workflow filenames would need to follow the new names, though no in-repo references remain