### PR TITLE
agent(github-delivery): sync issue status labels with comments (#6)

### DIFF
--- a/.codex/skills/firefly-github-delivery/SKILL.md
+++ b/.codex/skills/firefly-github-delivery/SKILL.md
@@ -24,22 +24,31 @@ Use local `gh` commands as a helper or fallback when terminal GitHub workflow is
 - Treat ambiguity in the issue as a blocker to clarify, not an invitation to invent scope.
 - Read the relevant repo docs for the touched area before editing.
 - Before substantive implementation work begins, update the source GitHub issue with a short status comment that says Codex has picked it up in `co-op` mode, names the working branch, and marks the issue status as `in progress`.
+- Before substantive implementation work begins, ensure the source issue carries the workflow labels `codex` and `co-op`, add the `in-progress` label, and remove `blocked` or `ready-for-review` if they are present from an older state.
 - Use `firefly-planning` when the issue needs refinement, sequencing, or issue breakdown before implementation.
 - Use `firefly-frontend-delivery` for frontend implementation work.
 - Use `firefly-backend-delivery` for backend implementation work.
 - Keep the implementation scoped to the issue acceptance criteria and constraints.
 - Keep one GitHub issue mapped to one focused branch and one reviewable PR.
 - If the work becomes blocked, add a follow-up issue comment that marks the status as `blocked` and explains the blocker clearly.
+- If the work becomes blocked, update labels so `blocked` is present and `in-progress` plus `ready-for-review` are removed.
 - Before handing work back for review, add a follow-up issue comment that marks the status as `ready for review` and summarizes validation, assumptions, and any remaining risks.
+- Before handing work back for review, update labels so `ready-for-review` is present and `in-progress` plus `blocked` are removed.
 
 ## Issue Status Rules
 
 - Treat issue comments as the required source of visible status during the current manual `co-op` workflow.
+- Treat issue comments as the required source of visible status during the current manual `co-op` workflow.
+- Mirror that visible status with issue labels in GitHub so the issue list can also be filtered by workflow state.
 - Required issue status transitions are:
   - `in progress` when Codex starts active work on the issue
   - `blocked` when Codex cannot continue without input or an external dependency
   - `ready for review` when implementation and validation are complete
-- When the repository label set supports it, mirror the same state with labels such as `blocked` or `ready-for-review`, but do not skip the required status comment.
+- Required workflow label transitions are:
+  - add `codex`, `co-op`, and `in-progress` when active work starts
+  - swap to `blocked` if work cannot continue
+  - swap to `ready-for-review` when the work is complete
+- Keep `in-progress`, `blocked`, and `ready-for-review` mutually exclusive so one issue shows one current workflow state.
 - Keep status comments short, specific, and human-readable so the issue timeline explains what happened without opening the branch or PR.
 
 ## Naming Rules
@@ -61,6 +70,7 @@ Use local `gh` commands as a helper or fallback when terminal GitHub workflow is
 - Add or update tests when appropriate for the touched behavior.
 - Run the relevant checks that exist.
 - Keep the issue status comment aligned with the current state of the work as it changes.
+- Keep the issue labels aligned with the same state transitions as the issue comments.
 - Rebase the issue branch onto the latest target branch before opening the PR when the workflow expects a clean linear history.
 - Leave final review and squash merge to the repository owner.
 

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -13,6 +13,7 @@ body:
 
         Codex workflow note:
         - When Codex picks up this issue in `co-op` mode, it should post issue status comments such as `in progress`, `blocked`, and `ready for review`
+        - It should also keep the workflow labels in sync, including `in-progress`, `blocked`, and `ready-for-review`
   - type: textarea
     id: goal
     attributes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,12 @@ When Codex works in this repo:
   - mark it `in progress` when work starts
   - mark it `blocked` if progress stops on an unresolved dependency or clarification
   - mark it `ready for review` when implementation and validation are complete
-- Treat issue comments as the required status signal in the current manual workflow, and mirror labels only when the repository label set supports them.
+- Keep the source GitHub issue labels aligned with the same state:
+  - ensure `codex`, `co-op`, and `in-progress` are present when active work starts
+  - swap to `blocked` if the issue becomes blocked
+  - swap to `ready-for-review` when the work is complete
+- Keep `in-progress`, `blocked`, and `ready-for-review` mutually exclusive so the current issue state is obvious from the issue list.
+- Treat issue comments as the required status signal in the current manual workflow, with labels kept in sync as a filterable mirror of that state.
 - Use `firefly-github-delivery` as the orchestration skill for issue-driven work.
 - Use `firefly-planning` when the issue needs refinement, decomposition, or sequencing before coding.
 - Use `firefly-frontend-delivery` or `firefly-backend-delivery` for area-specific implementation guidance once the touched area is clear.

--- a/docs/github-delivery/manual-codex-flow.md
+++ b/docs/github-delivery/manual-codex-flow.md
@@ -32,12 +32,15 @@ It can be revisited later after the co-op flow is stable.
 4. Run a Codex command that:
    - reads the issue details
    - posts an issue status update when work begins
+   - applies the matching issue labels when work begins
    - creates a focused branch
    - implements only the requested scope
    - runs relevant checks
    - posts a blocked status comment if the work cannot continue
+   - swaps the issue labels to the blocked state if the work cannot continue
    - rebases onto the latest target branch before PR creation
    - posts a ready-for-review status comment when the work is complete
+   - swaps the issue labels to the ready-for-review state when the work is complete
    - prepares a reviewable pull request
 5. Review the branch and PR output yourself before merge.
 
@@ -48,6 +51,7 @@ The exact trigger command can evolve, but it should always preserve the same con
 - require it to treat the issue as the source of truth
 - require it to read `AGENTS.md` and the relevant docs first
 - require it to post visible issue status comments as work progresses
+- require it to keep issue labels aligned with those status transitions
 - keep scope limited to the issue
 - require branch naming and PR title formatting to match repo conventions
 - require the PR body to include `Closes #<issue-number>`
@@ -64,12 +68,15 @@ When you build the manual command, the prompt should tell Codex to:
 - restate the issue goal, scope, acceptance criteria, constraints, and context
 - create a branch named for the issue
 - mark the issue `in progress` with a short status comment when work starts
+- apply `codex`, `co-op`, and `in-progress` labels when work starts
 - implement the smallest change that satisfies the issue
 - add or update tests when appropriate
 - run relevant checks
 - mark the issue `blocked` with a short status comment if work cannot continue
+- swap the issue labels to `blocked` if work cannot continue
 - rebase onto the latest target branch before opening the PR
 - mark the issue `ready for review` with a short status comment when implementation and validation are complete
+- swap the issue labels to `ready-for-review` when implementation and validation are complete
 - use the repo PR title convention
 - add `Closes #<issue-number>` to the PR body
 - prepare the change for human review

--- a/docs/github-delivery/overview.md
+++ b/docs/github-delivery/overview.md
@@ -12,6 +12,7 @@ The first goal is to prove that a small, focused issue can be created in GitHub,
 - You use the issue as the source of truth and work with Codex in `co-op` mode.
 - You manually run a command on the Mac server to let Codex pull the issue context and begin work.
 - Codex updates the issue timeline with visible status comments such as `in progress`, `blocked`, and `ready for review` while the work moves through the manual flow.
+- Codex also keeps the matching workflow labels in sync so the issue list reflects the same state.
 - Codex creates a focused branch, implements the change, runs the relevant checks, and prepares a PR.
 - You perform the final human review before merge.
 

--- a/docs/github-delivery/templates-and-management.md
+++ b/docs/github-delivery/templates-and-management.md
@@ -50,34 +50,42 @@ Recommended labels:
 - `task`
 - `codex`
 - `co-op`
+- `in-progress`
 - `blocked`
 - `ready-for-review`
 
 Recommended meaning:
 - `codex`: issue is suitable for Codex-assisted delivery
 - `co-op`: issue will be worked collaboratively by you and Codex
+- `in-progress`: Codex is actively working the issue
 - `blocked`: Codex or the maintainer found an unresolved dependency
 - `ready-for-review`: implementation is complete and awaiting your final review
 
-Labels are helpful, but they are not enough on their own because they do not explain why the state changed.
-For the current manual flow, Codex should always post issue status comments as the required visible status signal.
-When the label set exists, labels can mirror the same state for quicker filtering.
+Labels and status comments should work together.
+For the current manual flow, Codex should always post issue status comments as the required visible status signal and keep labels aligned so the issue list also reflects the current state.
 
 Recommended status comments:
 - `in progress` when Codex picks up the issue and starts active work
 - `blocked` when Codex cannot continue without clarification or an external dependency
 - `ready for review` when implementation and validation are complete
 
+Recommended label behavior:
+- keep `codex` and `co-op` on active Codex issues
+- add `in-progress` when Codex starts active work
+- replace `in-progress` with `blocked` if progress stops
+- replace `in-progress` or `blocked` with `ready-for-review` when implementation is complete
+- keep `in-progress`, `blocked`, and `ready-for-review` mutually exclusive
+
 ## Suggested Issue Lifecycle
 
 1. Create the issue with the `task` template.
 2. Treat it as `co-op`.
 3. Add `codex` only when you want Codex involved.
-4. When Codex starts the issue, it adds an `in progress` status comment to the issue.
+4. When Codex starts the issue, it adds an `in progress` status comment to the issue and applies `codex`, `co-op`, and `in-progress`.
 5. Run the manual Codex command on the Mac server for `co-op` issues during the trial phase.
-6. If Codex gets stuck, it adds a `blocked` status comment to the issue.
+6. If Codex gets stuck, it adds a `blocked` status comment to the issue and swaps the status label to `blocked`.
 7. Move the resulting PR into review.
-8. When Codex finishes, it adds a `ready for review` status comment to the issue and, when available, applies or keeps the `ready-for-review` label for your queue.
+8. When Codex finishes, it adds a `ready for review` status comment to the issue and swaps the status label to `ready-for-review`.
 
 ## Pull Request Template Direction
 


### PR DESCRIPTION
References #6

## Summary
- require Codex issue workflows to keep GitHub labels aligned with status comments
- document the `in-progress`, `blocked`, and `ready-for-review` label transitions across the GitHub delivery skill, AGENTS guidance, delivery docs, and task issue template
- preserve status comments as the required visible status signal while making issue list filtering reliable

## Why
- issue `#6` established comment-based status updates, but later issue work showed labels were still not being updated consistently
- adding and documenting label synchronization closes that workflow gap now that the repository has a dedicated status label set

## Validation
- ran `git diff --check`
- created the repository labels `task`, `codex`, `co-op`, `in-progress`, `blocked`, and `ready-for-review`
- updated issue `#11` to match its `ready for review` state with the new labels

## Assumptions
- this branch is a follow-on workflow improvement related to issue `#6`, not the implementation branch for issue `#6` itself
- status comments remain the primary timeline signal and labels act as the filterable mirror

## Risks
- this still relies on Codex following repository guidance rather than an automated enforcement check