### PR TITLE
agent(github-delivery): require issue refinement before coding (#15)

### DIFF
--- a/.codex/skills/firefly-github-delivery/SKILL.md
+++ b/.codex/skills/firefly-github-delivery/SKILL.md
@@ -21,10 +21,14 @@ Use local `gh` commands as a helper or fallback when terminal GitHub workflow is
 ## Orchestration Rules
 
 - Start by reading the issue carefully and restating its goal, scope, acceptance criteria, constraints, and useful context.
+- Start by reading the relevant repo docs for the touched area before proposing implementation.
 - Treat ambiguity in the issue as a blocker to clarify, not an invitation to invent scope.
-- Read the relevant repo docs for the touched area before editing.
 - Before substantive implementation work begins, update the source GitHub issue with a short status comment that says Codex has picked it up in `co-op` mode, names the working branch, and marks the issue status as `in progress`.
 - Before substantive implementation work begins, ensure the source issue carries the workflow labels `codex` and `co-op`, add the `in-progress` label, and remove `blocked` or `ready-for-review` if they are present from an older state.
+- When a developer asks Codex to pick up an issue, do not begin coding in the same turn.
+- First return to the developer with a refinement summary that narrows the issue into concrete `Goal`, `Scope`, and `Acceptance Criteria`.
+- Use issue comments for the refinement discussion when GitHub updates are part of the workflow.
+- Once the developer agrees on the refinement, update the issue body so the issue remains the source of truth.
 - Use `firefly-planning` when the issue needs refinement, sequencing, or issue breakdown before implementation.
 - Use `firefly-frontend-delivery` for frontend implementation work.
 - Use `firefly-backend-delivery` for backend implementation work.
@@ -66,6 +70,8 @@ Use local `gh` commands as a helper or fallback when terminal GitHub workflow is
 ## Delivery Rules
 
 - Create or switch to a branch named `issue-<number>-<descriptive-title>` before making issue-specific changes when branch work is part of the task.
+- Treat issue pickup as a refinement step first, not an implementation trigger.
+- Do not start implementation until the developer has confirmed the refined issue shape.
 - Implement the smallest change that satisfies the issue.
 - Add or update tests when appropriate for the touched behavior.
 - Run the relevant checks that exist.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,5 +1,5 @@
 name: Task
-description: Create a focused implementation issue.
+description: Create a rough implementation issue.
 title: "[Task] "
 labels:
   - task
@@ -12,40 +12,45 @@ body:
         - Do not prefix the issue title with feat, fix, docs, or similar change types
 
         Codex workflow note:
-        - When Codex picks up this issue in `co-op` mode, it should post issue status comments such as `in progress`, `blocked`, and `ready for review`
-        - It should also keep the workflow labels in sync, including `in-progress`, `blocked`, and `ready-for-review`
+        - Start with a plain-language request, then refine the issue together with Codex
+        - When Codex picks up this issue in `co-op` mode, it should read the issue and relevant docs, propose refinements, and wait for confirmation before coding
+        - Once refinement is agreed, the issue body should hold the final source of truth
+        - Codex should still post issue status comments such as `in progress`, `blocked`, and `ready for review`
+        - Codex should also keep the workflow labels in sync, including `in-progress`, `blocked`, and `ready-for-review`
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the request in broad plain language.
+      placeholder: Explain what you want Codex to help with.
+    validations:
+      required: true
   - type: textarea
     id: goal
     attributes:
       label: Goal
-      description: Describe the requested outcome in one clear sentence.
-      placeholder: Add a concise statement of what needs to be done.
-    validations:
-      required: true
+      description: Optional. Add a concise outcome if you already know it, or leave it for refinement with Codex.
+      placeholder: Add a one-sentence outcome if it is already clear.
   - type: textarea
     id: scope
     attributes:
       label: Scope
-      description: Call out the allowed files, modules, or areas to modify.
-      placeholder: Keep this task focused and reviewable.
-    validations:
-      required: true
+      description: Optional. Call out the allowed files, modules, or areas to modify.
+      placeholder: Keep this task focused and reviewable if you already know the boundaries.
   - type: textarea
     id: acceptance
     attributes:
       label: Acceptance Criteria
-      description: Define what must be true when the task is complete.
+      description: Optional. Define what must be true when the task is complete.
       placeholder: |
         - [ ] Condition 1
         - [ ] Condition 2
         - [ ] Condition 3
-    validations:
-      required: true
   - type: textarea
     id: constraints
     attributes:
       label: Constraints
-      description: State what must not be done and any important technical or product boundaries.
+      description: Optional. State what must not be done and any important technical or product boundaries.
       placeholder: Note boundaries, exclusions, or technical limitations.
   - type: textarea
     id: context

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,16 +130,17 @@ Future direction:
 ## AI Coding Workflow
 The expected delivery loop for future GitHub issues is:
 1. Review the issue and relevant docs before editing code.
-2. Create a focused branch for the issue.
-3. Implement the smallest change that satisfies the issue.
-4. Run the relevant tests and checks.
-5. Rebase the issue branch onto the latest target branch before opening the PR.
-6. Summarize assumptions, risks, and validation.
-7. Open a PR for review and squash merge by the repository owner.
+2. Refine the issue with the developer before implementation starts.
+3. Create or continue a focused branch for the issue.
+4. Implement the smallest change that satisfies the refined issue.
+5. Run the relevant tests and checks.
+6. Rebase the issue branch onto the latest target branch before opening the PR.
+7. Summarize assumptions, risks, and validation.
+8. Open a PR for review and squash merge by the repository owner.
 
 When Codex works in this repo:
 - Treat the GitHub issue as the source of truth for the requested change when the task comes from GitHub.
-- Expect implementation issues to use the `task` issue template with `Goal`, `Scope`, `Acceptance Criteria`, `Constraints`, and optional `Context`.
+- Expect implementation issues to use the `task` issue template with required `Description` plus optional `Goal`, `Scope`, `Acceptance Criteria`, `Constraints`, and `Context`.
 - Stop and surface ambiguity when the issue goal, scope, or constraints are not clear enough to implement safely.
 - Update the source GitHub issue with visible status comments during issue-driven work:
   - mark it `in progress` when work starts
@@ -151,6 +152,10 @@ When Codex works in this repo:
   - swap to `ready-for-review` when the work is complete
 - Keep `in-progress`, `blocked`, and `ready-for-review` mutually exclusive so the current issue state is obvious from the issue list.
 - Treat issue comments as the required status signal in the current manual workflow, with labels kept in sync as a filterable mirror of that state.
+- When a developer asks Codex to pick up an issue, do not jump straight into coding.
+- Read the relevant docs first, then return with a refinement summary that proposes `Goal`, `Scope`, and `Acceptance Criteria`.
+- Use comments for the refinement conversation when that helps collaboration.
+- Once the refinement is agreed, update the issue body so the final task definition remains in one canonical place.
 - Use `firefly-github-delivery` as the orchestration skill for issue-driven work.
 - Use `firefly-planning` when the issue needs refinement, decomposition, or sequencing before coding.
 - Use `firefly-frontend-delivery` or `firefly-backend-delivery` for area-specific implementation guidance once the touched area is clear.

--- a/docs/github-delivery/manual-codex-flow.md
+++ b/docs/github-delivery/manual-codex-flow.md
@@ -4,7 +4,7 @@ This document describes the first delivery loop to prove before adding OpenClaw 
 
 ## Goal
 
-Verify that Codex can take a small GitHub issue, work on it autonomously from the Mac server, and return a pull request that is ready for your final review.
+Verify that Codex can take a small GitHub issue, refine it with you from the Mac server, and then return a pull request that is ready for your final review.
 
 ## Preconditions
 
@@ -31,9 +31,13 @@ It can be revisited later after the co-op flow is stable.
 3. On the Mac server, start from a clean checkout of the repository.
 4. Run a Codex command that:
    - reads the issue details
+   - reads the relevant repo docs before implementation
    - posts an issue status update when work begins
    - applies the matching issue labels when work begins
    - creates a focused branch
+   - proposes refinements to the issue before implementation
+   - waits for your confirmation before coding
+   - updates the issue body once the refined task shape is agreed
    - implements only the requested scope
    - runs relevant checks
    - posts a blocked status comment if the work cannot continue
@@ -50,6 +54,8 @@ The exact trigger command can evolve, but it should always preserve the same con
 - point Codex at one issue only
 - require it to treat the issue as the source of truth
 - require it to read `AGENTS.md` and the relevant docs first
+- require it to refine the issue with you before coding starts
+- require it to update the issue body after refinement so the issue remains the source of truth
 - require it to post visible issue status comments as work progresses
 - require it to keep issue labels aligned with those status transitions
 - keep scope limited to the issue
@@ -66,9 +72,13 @@ The eventual OpenClaw command should call the same underlying workflow.
 When you build the manual command, the prompt should tell Codex to:
 - fetch and summarize the target issue
 - restate the issue goal, scope, acceptance criteria, constraints, and context
+- read the relevant repo docs before implementation work starts
 - create a branch named for the issue
 - mark the issue `in progress` with a short status comment when work starts
 - apply `codex`, `co-op`, and `in-progress` labels when work starts
+- propose any missing or unclear `Goal`, `Scope`, and `Acceptance Criteria` back to you before coding
+- wait for confirmation on the refined issue before implementation begins
+- update the issue body once the refinement is agreed
 - implement the smallest change that satisfies the issue
 - add or update tests when appropriate
 - run relevant checks
@@ -85,6 +95,7 @@ When you build the manual command, the prompt should tell Codex to:
 ## Success Criteria For The Trial
 
 The first trial is successful if:
+- Codex refines ambiguous issues with you before implementation starts
 - Codex stays within the issue scope
 - Codex produces a focused branch
 - Codex runs the relevant checks that exist

--- a/docs/github-delivery/overview.md
+++ b/docs/github-delivery/overview.md
@@ -10,10 +10,12 @@ The first goal is to prove that a small, focused issue can be created in GitHub,
 ### Stage 1: Manual Codex Execution
 - You create the issue yourself in GitHub.
 - You use the issue as the source of truth and work with Codex in `co-op` mode.
-- You manually run a command on the Mac server to let Codex pull the issue context and begin work.
+- You manually run a command on the Mac server to let Codex pull the issue context and begin refinement.
 - Codex updates the issue timeline with visible status comments such as `in progress`, `blocked`, and `ready for review` while the work moves through the manual flow.
 - Codex also keeps the matching workflow labels in sync so the issue list reflects the same state.
-- Codex creates a focused branch, implements the change, runs the relevant checks, and prepares a PR.
+- Codex reads the relevant docs, reviews the issue, proposes a refined `Goal`, `Scope`, and `Acceptance Criteria`, and waits for your confirmation before coding.
+- After you align on the task shape, Codex updates the issue body so the refined issue remains the source of truth.
+- Codex then creates or continues the focused branch, implements the change, runs the relevant checks, and prepares a PR.
 - You perform the final human review before merge.
 
 ### Stage 2: OpenClaw-Assisted Triggering
@@ -31,6 +33,7 @@ The first goal is to prove that a small, focused issue can be created in GitHub,
 
 - Keep issue creation human-led.
 - Keep the current workflow `co-op`.
+- Keep issue refinement collaborative before implementation starts.
 - Keep Codex branches focused on one issue.
 - Keep pull requests in draft until Codex has finished implementation and validation.
 - Keep merge approval human-led.

--- a/docs/github-delivery/templates-and-management.md
+++ b/docs/github-delivery/templates-and-management.md
@@ -14,9 +14,10 @@ Current repository file:
 
 The issue template should keep each task reviewable and unambiguous.
 The current fields should stay intentionally simple:
-- `Goal`
-- `Scope`
-- `Acceptance Criteria`
+- `Description`
+- `Goal` (optional at creation time)
+- `Scope` (optional at creation time)
+- `Acceptance Criteria` (optional at creation time)
 - `Constraints`
 - `Context` (optional)
 
@@ -27,7 +28,7 @@ Issue titles should follow the naming guidance in `naming-conventions.md`:
 ## Issue Writing Guidance
 
 Each Codex issue should:
-- describe one concrete outcome
+- describe one concrete request in plain language
 - define what done looks like
 - call out what is in scope and out of scope through scope and constraints
 - exclude unrelated cleanup
@@ -35,7 +36,7 @@ Each Codex issue should:
 Good issues are:
 - small enough for one branch and one PR
 - explicit about constraints
-- written so a coding agent does not have to infer product intent from scratch
+- easy to refine collaboratively before coding starts
 
 Avoid issues that:
 - mix frontend, backend, infra, and product changes without a clear single goal
@@ -69,6 +70,13 @@ Recommended status comments:
 - `blocked` when Codex cannot continue without clarification or an external dependency
 - `ready for review` when implementation and validation are complete
 
+Refinement guidance:
+- the issue can start as only a title plus `Description`
+- `Goal`, `Scope`, and `Acceptance Criteria` may be left blank by the human author
+- when Codex picks up the issue, it should read the relevant docs and propose refinements before coding
+- comments are the right place for the refinement conversation
+- once refinement is agreed, Codex should update the issue body so the final task definition lives in one place
+
 Recommended label behavior:
 - keep `codex` and `co-op` on active Codex issues
 - add `in-progress` when Codex starts active work
@@ -82,10 +90,12 @@ Recommended label behavior:
 2. Treat it as `co-op`.
 3. Add `codex` only when you want Codex involved.
 4. When Codex starts the issue, it adds an `in progress` status comment to the issue and applies `codex`, `co-op`, and `in-progress`.
-5. Run the manual Codex command on the Mac server for `co-op` issues during the trial phase.
-6. If Codex gets stuck, it adds a `blocked` status comment to the issue and swaps the status label to `blocked`.
-7. Move the resulting PR into review.
-8. When Codex finishes, it adds a `ready for review` status comment to the issue and swaps the status label to `ready-for-review`.
+5. Codex reads the relevant docs, reviews the issue, and proposes any missing or unclear `Goal`, `Scope`, and `Acceptance Criteria` back to you before coding.
+6. Once you agree on the refinement, Codex updates the issue body so it remains the source of truth.
+7. Run or continue the implementation work on the focused branch during the trial phase.
+8. If Codex gets stuck, it adds a `blocked` status comment to the issue and swaps the status label to `blocked`.
+9. Move the resulting PR into review.
+10. When Codex finishes, it adds a `ready for review` status comment to the issue and swaps the status label to `ready-for-review`.
 
 ## Pull Request Template Direction
 


### PR DESCRIPTION
## Summary
- simplify the task issue template so only the issue title and `Description` are required
- update the GitHub delivery docs and `AGENTS.md` so issue pickup starts with refinement before implementation
- update the Firefly GitHub delivery skill so Codex returns to the developer with a refinement summary and writes the agreed task shape back into the issue body

## Why
The current workflow assumed issues were already refined enough for implementation when Codex picked them up. This change keeps issue creation lightweight while making refinement an explicit step before coding starts.

Closes #15

## Validation
- Reviewed the updated issue template and delivery guidance for consistency
- Updated issue #15 body to match the agreed refined task definition
- No automated tests run because the change is limited to docs, template, and skill guidance

## Assumptions
- `in-progress` should remain the active work label while refinement or implementation is underway
- Comments are the right place for the refinement conversation, with the issue body holding the final agreed task shape

## Risks
- Future prompts or automation may still need tightening if there are edge cases around when branch creation happens relative to refinement
