### PR TITLE
agent(github-delivery): update issue templates (#19)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,45 @@
+name: Bug
+description: Report a focused bug to investigate and fix.
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: Describe the expected fixed outcome in one clear sentence.
+      placeholder: Explain what should be true after the bug is fixed.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Call out the affected route, workflow, component, service, or file area.
+      placeholder: Keep this bug report focused on one behavior or area.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Define what must be true when the bug is fixed.
+      placeholder: |
+        - [ ] Broken behavior is corrected
+        - [ ] Relevant regression risk is covered
+        - [ ] User-visible outcome is verified
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: Optional. State what must not be changed and any important technical or product boundaries.
+      placeholder: Note boundaries, exclusions, or technical limitations.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Optional background to help start the discussion with the agent.
+      placeholder: Add reproduction notes, observed behavior, screenshots, logs, or extra context.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,51 +1,36 @@
 name: Task
-description: Create a rough implementation issue.
+description: Create a focused implementation issue.
 title: "[Task] "
 labels:
   - task
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Issue title convention:
-        - Use a short descriptive phrase
-        - Do not prefix the issue title with feat, fix, docs, or similar change types
-
-        Codex workflow note:
-        - Start with a plain-language request, then refine the issue together with Codex
-        - When Codex picks up this issue in `co-op` mode, it should read the issue and relevant docs, propose refinements, and wait for confirmation before coding
-        - Once refinement is agreed, the issue body should hold the final source of truth
-        - Codex should still post issue status comments such as `in progress`, `blocked`, and `ready for review`
-        - Codex should also keep the workflow labels in sync, including `in-progress`, `blocked`, and `ready-for-review`
-  - type: textarea
-    id: description
-    attributes:
-      label: Description
-      description: Describe the request in broad plain language.
-      placeholder: Explain what you want Codex to help with.
-    validations:
-      required: true
   - type: textarea
     id: goal
     attributes:
       label: Goal
-      description: Optional. Add a concise outcome if you already know it, or leave it for refinement with Codex.
-      placeholder: Add a one-sentence outcome if it is already clear.
+      description: Describe the requested outcome in one clear sentence.
+      placeholder: Add a concise statement of what needs to be done.
+    validations:
+      required: true
   - type: textarea
     id: scope
     attributes:
       label: Scope
-      description: Optional. Call out the allowed files, modules, or areas to modify.
-      placeholder: Keep this task focused and reviewable if you already know the boundaries.
+      description: Call out the allowed files, modules, or areas to modify.
+      placeholder: Keep this task focused and reviewable.
+    validations:
+      required: true
   - type: textarea
     id: acceptance
     attributes:
       label: Acceptance Criteria
-      description: Optional. Define what must be true when the task is complete.
+      description: Define what must be true when the task is complete.
       placeholder: |
         - [ ] Condition 1
         - [ ] Condition 2
         - [ ] Condition 3
+    validations:
+      required: true
   - type: textarea
     id: constraints
     attributes:
@@ -53,8 +38,8 @@ body:
       description: Optional. State what must not be done and any important technical or product boundaries.
       placeholder: Note boundaries, exclusions, or technical limitations.
   - type: textarea
-    id: context
+    id: description
     attributes:
-      label: Context
-      description: Optional background, related files, links, examples, or references.
-      placeholder: Add any useful supporting context.
+      label: Description
+      description: Optional background to help start the discussion with the agent.
+      placeholder: Add any useful starting context, examples, links, or references.

--- a/docs/github-delivery/manual-codex-flow.md
+++ b/docs/github-delivery/manual-codex-flow.md
@@ -4,7 +4,7 @@ This document describes the first delivery loop to prove before adding OpenClaw 
 
 ## Goal
 
-Verify that Codex can take a small GitHub issue, refine it with you from the Mac server, and then return a pull request that is ready for your final review.
+Verify that Codex can take a small GitHub issue from the Mac server and then return a pull request that is ready for your final review.
 
 ## Preconditions
 
@@ -35,9 +35,8 @@ It can be revisited later after the co-op flow is stable.
    - posts an issue status update when work begins
    - applies the matching issue labels when work begins
    - creates a focused branch
-   - proposes refinements to the issue before implementation
-   - waits for your confirmation before coding
-   - updates the issue body once the refined task shape is agreed
+   - discusses missing issue details with you when needed
+   - updates the issue body once the final task shape is agreed
    - implements only the requested scope
    - runs relevant checks
    - posts a blocked status comment if the work cannot continue
@@ -54,8 +53,8 @@ The exact trigger command can evolve, but it should always preserve the same con
 - point Codex at one issue only
 - require it to treat the issue as the source of truth
 - require it to read `AGENTS.md` and the relevant docs first
-- require it to refine the issue with you before coding starts
-- require it to update the issue body after refinement so the issue remains the source of truth
+- require it to discuss missing issue details with you when needed
+- require it to update the issue body after agreement so the issue remains the source of truth
 - require it to post visible issue status comments as work progresses
 - require it to keep issue labels aligned with those status transitions
 - keep scope limited to the issue
@@ -71,14 +70,13 @@ The eventual OpenClaw command should call the same underlying workflow.
 
 When you build the manual command, the prompt should tell Codex to:
 - fetch and summarize the target issue
-- restate the issue goal, scope, acceptance criteria, constraints, and context
+- restate the issue goal, scope, acceptance criteria, constraints, and description
 - read the relevant repo docs before implementation work starts
 - create a branch named for the issue
 - mark the issue `in progress` with a short status comment when work starts
 - apply `codex`, `co-op`, and `in-progress` labels when work starts
-- propose any missing or unclear `Goal`, `Scope`, and `Acceptance Criteria` back to you before coding
-- wait for confirmation on the refined issue before implementation begins
-- update the issue body once the refinement is agreed
+- discuss missing or unclear issue details with you when needed
+- update the issue body once the final task shape is agreed
 - implement the smallest change that satisfies the issue
 - add or update tests when appropriate
 - run relevant checks
@@ -95,7 +93,6 @@ When you build the manual command, the prompt should tell Codex to:
 ## Success Criteria For The Trial
 
 The first trial is successful if:
-- Codex refines ambiguous issues with you before implementation starts
 - Codex stays within the issue scope
 - Codex produces a focused branch
 - Codex runs the relevant checks that exist

--- a/docs/github-delivery/overview.md
+++ b/docs/github-delivery/overview.md
@@ -10,11 +10,10 @@ The first goal is to prove that a small, focused issue can be created in GitHub,
 ### Stage 1: Manual Codex Execution
 - You create the issue yourself in GitHub.
 - You use the issue as the source of truth and work with Codex in `co-op` mode.
-- You manually run a command on the Mac server to let Codex pull the issue context and begin refinement.
+- You manually run a command on the Mac server to let Codex pull the issue context and begin work.
 - Codex updates the issue timeline with visible status comments such as `in progress`, `blocked`, and `ready for review` while the work moves through the manual flow.
 - Codex also keeps the matching workflow labels in sync so the issue list reflects the same state.
-- Codex reads the relevant docs, reviews the issue, proposes a refined `Goal`, `Scope`, and `Acceptance Criteria`, and waits for your confirmation before coding.
-- After you align on the task shape, Codex updates the issue body so the refined issue remains the source of truth.
+- If the issue body is incomplete, you can discuss the missing details with Codex and then update the issue so it remains the source of truth.
 - Codex then creates or continues the focused branch, implements the change, runs the relevant checks, and prepares a PR.
 - You perform the final human review before merge.
 
@@ -33,7 +32,7 @@ The first goal is to prove that a small, focused issue can be created in GitHub,
 
 - Keep issue creation human-led.
 - Keep the current workflow `co-op`.
-- Keep issue refinement collaborative before implementation starts.
+- Keep issue details easy to complete collaboratively when needed.
 - Keep Codex branches focused on one issue.
 - Keep pull requests in draft until Codex has finished implementation and validation.
 - Keep merge approval human-led.

--- a/docs/github-delivery/templates-and-management.md
+++ b/docs/github-delivery/templates-and-management.md
@@ -11,15 +11,22 @@ Use a dedicated issue template for implementation work intended for Codex.
 
 Current repository file:
 - `.github/ISSUE_TEMPLATE/task.yml`
+- `.github/ISSUE_TEMPLATE/bug.yml`
 
-The issue template should keep each task reviewable and unambiguous.
-The current fields should stay intentionally simple:
-- `Description`
-- `Goal` (optional at creation time)
-- `Scope` (optional at creation time)
-- `Acceptance Criteria` (optional at creation time)
+The issue templates should keep each issue reviewable and unambiguous.
+The task template fields should stay intentionally simple:
+- `Goal`
+- `Scope`
+- `Acceptance Criteria`
 - `Constraints`
-- `Context` (optional)
+- `Description` (optional)
+
+The bug template should use the same lightweight structure:
+- `Goal`
+- `Scope`
+- `Acceptance Criteria`
+- `Constraints`
+- `Description` (optional)
 
 Issue titles should follow the naming guidance in `naming-conventions.md`:
 - short descriptive phrase
@@ -32,11 +39,12 @@ Each Codex issue should:
 - define what done looks like
 - call out what is in scope and out of scope through scope and constraints
 - exclude unrelated cleanup
+- allow the author to start with a title and discuss the remaining body details with the agent before the final issue shape is settled
 
 Good issues are:
 - small enough for one branch and one PR
 - explicit about constraints
-- easy to refine collaboratively before coding starts
+- easy to complete collaboratively before coding starts
 
 Avoid issues that:
 - mix frontend, backend, infra, and product changes without a clear single goal
@@ -70,12 +78,9 @@ Recommended status comments:
 - `blocked` when Codex cannot continue without clarification or an external dependency
 - `ready for review` when implementation and validation are complete
 
-Refinement guidance:
-- the issue can start as only a title plus `Description`
-- `Goal`, `Scope`, and `Acceptance Criteria` may be left blank by the human author
-- when Codex picks up the issue, it should read the relevant docs and propose refinements before coding
-- comments are the right place for the refinement conversation
-- once refinement is agreed, Codex should update the issue body so the final task definition lives in one place
+Issue completion guidance:
+- the maintainer may start with just the issue title and then discuss the issue with Codex
+- once the details are settled, the issue body should capture the final `Goal`, `Scope`, `Acceptance Criteria`, and any optional `Description`
 
 Recommended label behavior:
 - keep `codex` and `co-op` on active Codex issues
@@ -90,12 +95,11 @@ Recommended label behavior:
 2. Treat it as `co-op`.
 3. Add `codex` only when you want Codex involved.
 4. When Codex starts the issue, it adds an `in progress` status comment to the issue and applies `codex`, `co-op`, and `in-progress`.
-5. Codex reads the relevant docs, reviews the issue, and proposes any missing or unclear `Goal`, `Scope`, and `Acceptance Criteria` back to you before coding.
-6. Once you agree on the refinement, Codex updates the issue body so it remains the source of truth.
-7. Run or continue the implementation work on the focused branch during the trial phase.
-8. If Codex gets stuck, it adds a `blocked` status comment to the issue and swaps the status label to `blocked`.
-9. Move the resulting PR into review.
-10. When Codex finishes, it adds a `ready for review` status comment to the issue and swaps the status label to `ready-for-review`.
+5. If the issue body is still incomplete, discuss the missing details with Codex and then update the issue so it remains the source of truth.
+6. Run or continue the implementation work on the focused branch during the trial phase.
+7. If Codex gets stuck, it adds a `blocked` status comment to the issue and swaps the status label to `blocked`.
+8. Move the resulting PR into review.
+9. When Codex finishes, it adds a `ready for review` status comment to the issue and swaps the status label to `ready-for-review`.
 
 ## Pull Request Template Direction
 


### PR DESCRIPTION
Closes #19

## Summary
- simplify the task issue template while keeping the `[Task]` title prefix
- require `Goal`, `Scope`, and `Acceptance Criteria` in the task template
- make `Description` optional and remove the extra instructional notes block
- add a matching `[Bug]` template with the same lightweight structure
- align GitHub delivery docs with the updated co-op issue workflow

## Why
The repo had drifted toward a title-plus-description refinement flow that no longer matched the desired issue authoring workflow. This change keeps the structured issue body, makes the optional context lighter, and adds a bug template without reintroducing heavy notes.

## Validation
- parsed `.github/ISSUE_TEMPLATE/task.yml` with Ruby YAML
- parsed `.github/ISSUE_TEMPLATE/bug.yml` with Ruby YAML
- reviewed the final diff for template and workflow doc consistency

## Assumptions
- maintainers may still start with only an issue title and then complete the body through discussion with Codex
- the bug template should mirror the task template closely, including optional `Constraints`

## Risks
- existing workflow docs outside the GitHub delivery area may still mention older issue-writing habits if they are added or edited later