### PR TITLE
fix(github): relax issue template requirements (#24)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -5,21 +5,23 @@ labels:
   - bug
 body:
   - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Optional background to help start the discussion with the agent.
+      placeholder: Add reproduction notes, observed behavior, screenshots, logs, or extra context.
+  - type: textarea
     id: goal
     attributes:
       label: Goal
       description: Describe the expected fixed outcome in one clear sentence.
       placeholder: Explain what should be true after the bug is fixed.
-    validations:
-      required: true
   - type: textarea
     id: scope
     attributes:
       label: Scope
       description: Call out the affected route, workflow, component, service, or file area.
       placeholder: Keep this bug report focused on one behavior or area.
-    validations:
-      required: true
   - type: textarea
     id: acceptance
     attributes:
@@ -29,17 +31,9 @@ body:
         - [ ] Broken behavior is corrected
         - [ ] Relevant regression risk is covered
         - [ ] User-visible outcome is verified
-    validations:
-      required: true
   - type: textarea
     id: constraints
     attributes:
       label: Constraints
       description: Optional. State what must not be changed and any important technical or product boundaries.
       placeholder: Note boundaries, exclusions, or technical limitations.
-  - type: textarea
-    id: description
-    attributes:
-      label: Description
-      description: Optional background to help start the discussion with the agent.
-      placeholder: Add reproduction notes, observed behavior, screenshots, logs, or extra context.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -5,21 +5,23 @@ labels:
   - task
 body:
   - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Optional background to help start the discussion with the agent.
+      placeholder: Add any useful starting context, examples, links, or references.
+  - type: textarea
     id: goal
     attributes:
       label: Goal
       description: Describe the requested outcome in one clear sentence.
       placeholder: Add a concise statement of what needs to be done.
-    validations:
-      required: true
   - type: textarea
     id: scope
     attributes:
       label: Scope
       description: Call out the allowed files, modules, or areas to modify.
       placeholder: Keep this task focused and reviewable.
-    validations:
-      required: true
   - type: textarea
     id: acceptance
     attributes:
@@ -29,17 +31,9 @@ body:
         - [ ] Condition 1
         - [ ] Condition 2
         - [ ] Condition 3
-    validations:
-      required: true
   - type: textarea
     id: constraints
     attributes:
       label: Constraints
       description: Optional. State what must not be done and any important technical or product boundaries.
       placeholder: Note boundaries, exclusions, or technical limitations.
-  - type: textarea
-    id: description
-    attributes:
-      label: Description
-      description: Optional background to help start the discussion with the agent.
-      placeholder: Add any useful starting context, examples, links, or references.


### PR DESCRIPTION
Closes #24

## Summary
- make Description the first field in both issue templates
- remove required validations so title-only issues can be created

## Why
- allows developers to start with a title and refine the issue body collaboratively with Codex

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/ISSUE_TEMPLATE/task.yml"); YAML.load_file(".github/ISSUE_TEMPLATE/bug.yml"); puts "YAML OK"'\n\n## Assumptions\n- the existing docs already describe Description as optional, so no docs change was needed\n\n## Risks\n- GitHub issue forms will now allow sparse issue bodies, so some issues may need refinement before implementation starts