### PR TITLE
feat(web): add admin job management and paged job search (#26)

### DIFF
--- a/apps/web/src/api/jobs/jobs.api.ts
+++ b/apps/web/src/api/jobs/jobs.api.ts
@@ -1,0 +1,78 @@
+import { deleteJson, deleteRequest, getJson, postJson, putJson } from "@/lib/http/client";
+import type {
+  CreateJobRequestDto,
+  DeleteJobsResponseDto,
+  GetJobsPageQueryDto,
+  HideJobsResponseDto,
+  IdBatchRequestDto,
+  JobDetailsResponseDto,
+  JobsPageResponseDto,
+  UpdateJobRequestDto
+} from "@/api/jobs/jobs.types";
+
+export async function getJobsPage(query: GetJobsPageQueryDto): Promise<JobsPageResponseDto> {
+  const searchParams = new URLSearchParams({
+    pageIndex: String(query.pageIndex),
+    pageSize: String(query.pageSize)
+  });
+
+  appendOptional(searchParams, "keyword", query.keyword);
+  appendOptional(searchParams, "company", query.company);
+  appendOptional(searchParams, "postcode", query.postcode);
+  appendOptional(searchParams, "location", query.location);
+  appendOptional(searchParams, "sourceName", query.sourceName);
+  appendOptional(searchParams, "categoryTag", query.categoryTag);
+
+  if (query.isHidden !== undefined) {
+    searchParams.set("isHidden", String(query.isHidden));
+  }
+
+  return getJson<JobsPageResponseDto>(`/api/job-search/jobs?${searchParams.toString()}`);
+}
+
+export async function getJobById(jobId: number): Promise<JobDetailsResponseDto> {
+  return getJson<JobDetailsResponseDto>(`/api/job-search/jobs/${jobId}`);
+}
+
+export async function createJob(request: CreateJobRequestDto): Promise<JobDetailsResponseDto> {
+  return postJson<JobDetailsResponseDto, CreateJobRequestDto>("/api/job-search/jobs", request);
+}
+
+export async function updateJob(
+  jobId: number,
+  request: UpdateJobRequestDto
+): Promise<JobDetailsResponseDto> {
+  return putJson<JobDetailsResponseDto, UpdateJobRequestDto>(
+    `/api/job-search/jobs/${jobId}`,
+    request
+  );
+}
+
+export async function hideJob(jobId: number): Promise<HideJobsResponseDto> {
+  return postJson<HideJobsResponseDto, Record<string, never>>(
+    `/api/job-search/jobs/${jobId}/hide`,
+    {}
+  );
+}
+
+export async function hideJobs(ids: number[]): Promise<HideJobsResponseDto> {
+  return postJson<HideJobsResponseDto, IdBatchRequestDto>("/api/job-search/jobs/hide", {
+    ids
+  });
+}
+
+export async function deleteJob(jobId: number): Promise<void> {
+  await deleteRequest(`/api/job-search/jobs/${jobId}`);
+}
+
+export async function deleteJobs(ids: number[]): Promise<DeleteJobsResponseDto> {
+  return deleteJson<DeleteJobsResponseDto, IdBatchRequestDto>("/api/job-search/jobs", { ids });
+}
+
+function appendOptional(params: URLSearchParams, key: string, value: string | undefined) {
+  if (!value) {
+    return;
+  }
+
+  params.set(key, value);
+}

--- a/apps/web/src/api/jobs/jobs.types.ts
+++ b/apps/web/src/api/jobs/jobs.types.ts
@@ -1,0 +1,115 @@
+export type JobDetailsResponseDto = {
+  id: number;
+  jobRefreshRunId: number | null;
+  sourceName: string;
+  sourceJobId: string;
+  sourceAdReference: string | null;
+  title: string;
+  description: string;
+  summary: string;
+  url: string;
+  company: string;
+  companyDisplayName: string | null;
+  companyCanonicalName: string | null;
+  postcode: string;
+  locationName: string;
+  locationDisplayName: string | null;
+  locationAreaJson: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  categoryTag: string | null;
+  categoryLabel: string | null;
+  salaryMin: number | null;
+  salaryMax: number | null;
+  salaryCurrency: string | null;
+  salaryIsPredicted: boolean | null;
+  contractTime: string | null;
+  contractType: string | null;
+  isFullTime: boolean;
+  isPartTime: boolean;
+  isPermanent: boolean;
+  isContract: boolean;
+  isRemote: boolean;
+  postedAtUtc: string;
+  importedAtUtc: string;
+  lastSeenAtUtc: string;
+  isHidden: boolean;
+  rawPayloadJson: string;
+};
+
+export type JobsPageResponseDto = {
+  pageIndex: number;
+  pageSize: number;
+  totalCount: number;
+  items: JobDetailsResponseDto[];
+};
+
+export type GetJobsPageQueryDto = {
+  pageIndex: number;
+  pageSize: number;
+  keyword?: string;
+  company?: string;
+  postcode?: string;
+  location?: string;
+  sourceName?: string;
+  categoryTag?: string;
+  isHidden?: boolean;
+};
+
+export type JobWriteRequestDto = {
+  jobRefreshRunId: number | null;
+  sourceName: string;
+  sourceJobId: string;
+  sourceAdReference: string | null;
+  title: string;
+  description: string;
+  summary: string;
+  url: string;
+  company: string;
+  companyDisplayName: string | null;
+  companyCanonicalName: string | null;
+  postcode: string;
+  locationName: string;
+  locationDisplayName: string | null;
+  locationAreaJson: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  categoryTag: string | null;
+  categoryLabel: string | null;
+  salaryMin: number | null;
+  salaryMax: number | null;
+  salaryCurrency: string | null;
+  salaryIsPredicted: boolean | null;
+  contractTime: string | null;
+  contractType: string | null;
+  isFullTime: boolean;
+  isPartTime: boolean;
+  isPermanent: boolean;
+  isContract: boolean;
+  isRemote: boolean;
+  postedAtUtc: string;
+  importedAtUtc: string;
+  lastSeenAtUtc: string;
+  isHidden: boolean;
+  rawPayloadJson: string;
+};
+
+export type CreateJobRequestDto = JobWriteRequestDto;
+export type UpdateJobRequestDto = JobWriteRequestDto;
+
+export type HideJobsResponseDto = {
+  hiddenCount: number;
+  hiddenIds: number[];
+  missingIds: number[];
+};
+
+export type DeleteJobsResponseDto = {
+  deletedCount: number;
+  deletedIds: number[];
+  missingIds: number[];
+  notHiddenIds: number[];
+};
+
+export type IdBatchRequestDto = {
+  ids: number[];
+};

--- a/apps/web/src/app/AppRouter.tsx
+++ b/apps/web/src/app/AppRouter.tsx
@@ -1,5 +1,8 @@
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
 import { ProtectedRoute } from "@/features/auth/components/ProtectedRoute";
+import { AppJobCreatePage } from "@/routes/AppJobCreatePage";
+import { AppJobDetailPage } from "@/routes/AppJobDetailPage";
+import { AppJobsPage } from "@/routes/AppJobsPage";
 import { AppHomePage } from "@/routes/AppHomePage";
 import { JobDetailPage } from "@/routes/JobDetailPage";
 import { LoginPage } from "@/routes/LoginPage";
@@ -28,6 +31,30 @@ const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <AppHomePage />
+      </ProtectedRoute>
+    )
+  },
+  {
+    path: "/admin/manage-jobs",
+    element: (
+      <ProtectedRoute>
+        <AppJobsPage />
+      </ProtectedRoute>
+    )
+  },
+  {
+    path: "/admin/manage-jobs/new",
+    element: (
+      <ProtectedRoute>
+        <AppJobCreatePage />
+      </ProtectedRoute>
+    )
+  },
+  {
+    path: "/admin/manage-jobs/:jobId",
+    element: (
+      <ProtectedRoute>
+        <AppJobDetailPage />
       </ProtectedRoute>
     )
   }

--- a/apps/web/src/app/AppRouter.tsx
+++ b/apps/web/src/app/AppRouter.tsx
@@ -1,3 +1,4 @@
+import { AdminRoute } from "@/features/auth/components/AdminRoute";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
 import { ProtectedRoute } from "@/features/auth/components/ProtectedRoute";
 import { AppJobCreatePage } from "@/routes/AppJobCreatePage";
@@ -37,25 +38,25 @@ const router = createBrowserRouter([
   {
     path: "/admin/manage-jobs",
     element: (
-      <ProtectedRoute>
+      <AdminRoute>
         <AppJobsPage />
-      </ProtectedRoute>
+      </AdminRoute>
     )
   },
   {
     path: "/admin/manage-jobs/new",
     element: (
-      <ProtectedRoute>
+      <AdminRoute>
         <AppJobCreatePage />
-      </ProtectedRoute>
+      </AdminRoute>
     )
   },
   {
     path: "/admin/manage-jobs/:jobId",
     element: (
-      <ProtectedRoute>
+      <AdminRoute>
         <AppJobDetailPage />
-      </ProtectedRoute>
+      </AdminRoute>
     )
   }
 ]);

--- a/apps/web/src/components/AppHeader.test.tsx
+++ b/apps/web/src/components/AppHeader.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vitest";
+import { theme } from "@/app/theme";
+import { AppHeader } from "@/components/AppHeader";
+import { useSessionStore } from "@/store/session.store";
+
+describe("AppHeader", () => {
+  afterEach(() => {
+    useSessionStore.setState({
+      user: null,
+      isAuthenticated: false
+    });
+  });
+
+  it("shows authenticated actions on public pages when a user session exists", () => {
+    useSessionStore.setState({
+      user: {
+        userAccount: "admin",
+        displayName: "Admin",
+        role: "admin",
+        email: "admin@example.com"
+      },
+      isAuthenticated: true
+    });
+
+    render(
+      <ThemeProvider theme={theme}>
+        <MemoryRouter>
+          <AppHeader />
+        </MemoryRouter>
+      </ThemeProvider>
+    );
+
+    expect(screen.queryByRole("link", { name: "Sign in" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign out" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Workspace" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -4,6 +4,7 @@ import LoginRoundedIcon from "@mui/icons-material/LoginRounded";
 import LogoutRoundedIcon from "@mui/icons-material/LogoutRounded";
 import SearchRoundedIcon from "@mui/icons-material/SearchRounded";
 import VisibilityRoundedIcon from "@mui/icons-material/VisibilityRounded";
+import WorkOutlineRoundedIcon from "@mui/icons-material/WorkOutlineRounded";
 import { Button } from "@mui/material";
 import type { ReactNode } from "react";
 import { NavLink, useNavigate } from "react-router-dom";
@@ -21,7 +22,8 @@ const publicLinks = [
 
 const authenticatedLinks = [
   ...publicLinks,
-  { to: "/app", label: "Workspace", icon: <DashboardRoundedIcon fontSize="inherit" /> }
+  { to: "/app", label: "Workspace", icon: <DashboardRoundedIcon fontSize="inherit" /> },
+  { to: "/admin/manage-jobs", label: "Manage jobs", icon: <WorkOutlineRoundedIcon fontSize="inherit" /> }
 ];
 
 export function AppHeader({ variant = "public", actions }: AppHeaderProps) {

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -30,7 +30,8 @@ export function AppHeader({ variant = "public", actions }: AppHeaderProps) {
   const navigate = useNavigate();
   const user = useSessionStore((state) => state.user);
   const signOut = useSessionStore((state) => state.signOut);
-  const links = variant === "authenticated" ? authenticatedLinks : publicLinks;
+  const effectiveVariant = user ? "authenticated" : variant;
+  const links = effectiveVariant === "authenticated" ? authenticatedLinks : publicLinks;
 
   function handleSignOut() {
     signOut();
@@ -73,7 +74,7 @@ export function AppHeader({ variant = "public", actions }: AppHeaderProps) {
 
         <div className="flex items-center gap-3">
           {actions}
-          {variant === "authenticated" && user ? (
+          {effectiveVariant === "authenticated" && user ? (
             <>
               <div className="hidden text-right sm:block">
                 <p className="text-sm font-medium text-foreground">{user.displayName}</p>

--- a/apps/web/src/features/auth/components/AdminRoute.tsx
+++ b/apps/web/src/features/auth/components/AdminRoute.tsx
@@ -2,13 +2,18 @@ import type { PropsWithChildren } from "react";
 import { Navigate, useLocation } from "react-router-dom";
 import { useSessionStore } from "@/store/session.store";
 
-export function ProtectedRoute({ children }: PropsWithChildren) {
+export function AdminRoute({ children }: PropsWithChildren) {
   const isAuthenticated = useSessionStore((state) => state.isAuthenticated);
+  const user = useSessionStore((state) => state.user);
   const location = useLocation();
   const from = `${location.pathname}${location.search}`;
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace state={{ from }} />;
+  }
+
+  if (user?.role !== "admin") {
+    return <Navigate to="/app" replace />;
   }
 
   return children;

--- a/apps/web/src/features/jobs/components/JobEditorActions.tsx
+++ b/apps/web/src/features/jobs/components/JobEditorActions.tsx
@@ -1,0 +1,73 @@
+import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
+import SaveRoundedIcon from "@mui/icons-material/SaveRounded";
+import VisibilityOffRoundedIcon from "@mui/icons-material/VisibilityOffRounded";
+import { Button } from "@mui/material";
+import { SectionCard } from "@/components/SectionCard";
+
+type JobEditorActionsProps = {
+  isAdmin: boolean;
+  isCreateMode: boolean;
+  isDeleting: boolean;
+  isHiding: boolean;
+  isSaving: boolean;
+  onDelete: () => void;
+  onHide: () => void;
+};
+
+export function JobEditorActions({
+  isAdmin,
+  isCreateMode,
+  isDeleting,
+  isHiding,
+  isSaving,
+  onDelete,
+  onHide
+}: JobEditorActionsProps) {
+  return (
+    <SectionCard className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between">
+      <div className="text-sm text-foreground-secondary">
+        {isCreateMode
+          ? "Create a new job resource in the backend table."
+          : "Save changes, hide the job, or delete it after it has been hidden."}
+      </div>
+      <div className="flex flex-wrap gap-3">
+        {!isCreateMode ? (
+          <Button
+            type="button"
+            variant="outlined"
+            color="inherit"
+            startIcon={<VisibilityOffRoundedIcon />}
+            disabled={!isAdmin || isHiding || isSaving || isDeleting}
+            onClick={onHide}
+          >
+            {isHiding ? "Hiding..." : "Hide job"}
+          </Button>
+        ) : null}
+        {!isCreateMode ? (
+          <Button
+            type="button"
+            color="error"
+            variant="outlined"
+            startIcon={<DeleteOutlineRoundedIcon />}
+            disabled={!isAdmin || isDeleting || isSaving || isHiding}
+            onClick={onDelete}
+          >
+            {isDeleting ? "Deleting..." : "Delete job"}
+          </Button>
+        ) : null}
+        <Button
+          type="submit"
+          variant="contained"
+          startIcon={<SaveRoundedIcon />}
+          disabled={!isAdmin || isSaving || isHiding || isDeleting}
+          sx={{
+            bgcolor: "accent.main",
+            "&:hover": { bgcolor: "accent.dark" }
+          }}
+        >
+          {isSaving ? "Saving..." : isCreateMode ? "Create job" : "Save changes"}
+        </Button>
+      </div>
+    </SectionCard>
+  );
+}

--- a/apps/web/src/features/jobs/components/JobEditorAlerts.tsx
+++ b/apps/web/src/features/jobs/components/JobEditorAlerts.tsx
@@ -1,0 +1,27 @@
+import { Alert } from "@mui/material";
+
+type JobEditorAlertsProps = {
+  errorMessage: string | null;
+  isAdmin: boolean;
+  saveMessage: string | null;
+};
+
+export function JobEditorAlerts({
+  errorMessage,
+  isAdmin,
+  saveMessage
+}: JobEditorAlertsProps) {
+  return (
+    <>
+      {!isAdmin ? (
+        <Alert severity="info" sx={{ mt: 4 }}>
+          You can inspect the job resource, but save, hide, and delete actions require an admin
+          role from the backend API.
+        </Alert>
+      ) : null}
+
+      {saveMessage ? <Alert severity="success" sx={{ mt: 4 }}>{saveMessage}</Alert> : null}
+      {errorMessage ? <Alert severity="error" sx={{ mt: 4 }}>{errorMessage}</Alert> : null}
+    </>
+  );
+}

--- a/apps/web/src/features/jobs/components/JobEditorClassificationSection.tsx
+++ b/apps/web/src/features/jobs/components/JobEditorClassificationSection.tsx
@@ -1,0 +1,79 @@
+import { TextField } from "@mui/material";
+import type { CreateJobRequestDto } from "@/api/jobs/jobs.types";
+import { JobFieldSection } from "@/features/jobs/components/JobFieldSection";
+import {
+  setNullableNumberValue,
+  setNullableStringValue,
+  type JobFormSetter
+} from "@/features/jobs/components/JobEditorFormState";
+
+type JobEditorClassificationSectionProps = {
+  formValues: CreateJobRequestDto;
+  setFormValues: JobFormSetter;
+};
+
+export function JobEditorClassificationSection({
+  formValues,
+  setFormValues
+}: JobEditorClassificationSectionProps) {
+  return (
+    <JobFieldSection title="Classification and salary">
+      <TextField
+        label="Category tag"
+        value={formValues.categoryTag ?? ""}
+        onChange={(event) =>
+          setNullableStringValue(setFormValues, "categoryTag", event.target.value)
+        }
+        fullWidth
+      />
+      <TextField
+        label="Category label"
+        value={formValues.categoryLabel ?? ""}
+        onChange={(event) =>
+          setNullableStringValue(setFormValues, "categoryLabel", event.target.value)
+        }
+        fullWidth
+      />
+      <TextField
+        label="Salary min"
+        value={formValues.salaryMin ?? ""}
+        onChange={(event) =>
+          setNullableNumberValue(setFormValues, "salaryMin", event.target.value)
+        }
+        fullWidth
+      />
+      <TextField
+        label="Salary max"
+        value={formValues.salaryMax ?? ""}
+        onChange={(event) =>
+          setNullableNumberValue(setFormValues, "salaryMax", event.target.value)
+        }
+        fullWidth
+      />
+      <TextField
+        label="Salary currency"
+        value={formValues.salaryCurrency ?? ""}
+        onChange={(event) =>
+          setNullableStringValue(setFormValues, "salaryCurrency", event.target.value)
+        }
+        fullWidth
+      />
+      <TextField
+        label="Contract time"
+        value={formValues.contractTime ?? ""}
+        onChange={(event) =>
+          setNullableStringValue(setFormValues, "contractTime", event.target.value)
+        }
+        fullWidth
+      />
+      <TextField
+        label="Contract type"
+        value={formValues.contractType ?? ""}
+        onChange={(event) =>
+          setNullableStringValue(setFormValues, "contractType", event.target.value)
+        }
+        fullWidth
+      />
+    </JobFieldSection>
+  );
+}

--- a/apps/web/src/features/jobs/components/JobEditorCoreSection.tsx
+++ b/apps/web/src/features/jobs/components/JobEditorCoreSection.tsx
@@ -1,0 +1,58 @@
+import { TextField } from "@mui/material";
+import type { CreateJobRequestDto } from "@/api/jobs/jobs.types";
+import { JobFieldSection } from "@/features/jobs/components/JobFieldSection";
+import { setStringValue, type JobFormSetter } from "@/features/jobs/components/JobEditorFormState";
+
+type JobEditorCoreSectionProps = {
+  formValues: CreateJobRequestDto;
+  setFormValues: JobFormSetter;
+};
+
+export function JobEditorCoreSection({
+  formValues,
+  setFormValues
+}: JobEditorCoreSectionProps) {
+  return (
+    <JobFieldSection title="Core">
+      <TextField
+        label="Title"
+        value={formValues.title}
+        onChange={(event) => setStringValue(setFormValues, "title", event.target.value)}
+        fullWidth
+        required
+      />
+      <TextField
+        label="Company"
+        value={formValues.company}
+        onChange={(event) => setStringValue(setFormValues, "company", event.target.value)}
+        fullWidth
+        required
+      />
+      <TextField
+        label="Job URL"
+        value={formValues.url}
+        onChange={(event) => setStringValue(setFormValues, "url", event.target.value)}
+        fullWidth
+        required
+      />
+      <TextField
+        label="Summary"
+        value={formValues.summary}
+        onChange={(event) => setStringValue(setFormValues, "summary", event.target.value)}
+        fullWidth
+        required
+        multiline
+        minRows={3}
+      />
+      <TextField
+        label="Description"
+        value={formValues.description}
+        onChange={(event) => setStringValue(setFormValues, "description", event.target.value)}
+        fullWidth
+        required
+        multiline
+        minRows={5}
+      />
+    </JobFieldSection>
+  );
+}

--- a/apps/web/src/features/jobs/components/JobEditorFlagsSection.tsx
+++ b/apps/web/src/features/jobs/components/JobEditorFlagsSection.tsx
@@ -1,0 +1,116 @@
+import { Checkbox, FormControlLabel, TextField } from "@mui/material";
+import type { CreateJobRequestDto } from "@/api/jobs/jobs.types";
+import { JobFieldSection } from "@/features/jobs/components/JobFieldSection";
+import {
+  setBooleanValue,
+  setNullableBooleanValue,
+  setStringValue,
+  type JobFormSetter
+} from "@/features/jobs/components/JobEditorFormState";
+
+type JobEditorFlagsSectionProps = {
+  formValues: CreateJobRequestDto;
+  setFormValues: JobFormSetter;
+};
+
+export function JobEditorFlagsSection({
+  formValues,
+  setFormValues
+}: JobEditorFlagsSectionProps) {
+  return (
+    <JobFieldSection title="Flags and timestamps">
+      <div className="grid gap-2 md:col-span-2 md:grid-cols-3">
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={formValues.isFullTime}
+              onChange={(event) => setBooleanValue(setFormValues, "isFullTime", event.target.checked)}
+            />
+          }
+          label="Full time"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={formValues.isPartTime}
+              onChange={(event) => setBooleanValue(setFormValues, "isPartTime", event.target.checked)}
+            />
+          }
+          label="Part time"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={formValues.isPermanent}
+              onChange={(event) =>
+                setBooleanValue(setFormValues, "isPermanent", event.target.checked)
+              }
+            />
+          }
+          label="Permanent"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={formValues.isContract}
+              onChange={(event) =>
+                setBooleanValue(setFormValues, "isContract", event.target.checked)
+              }
+            />
+          }
+          label="Contract"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={formValues.isRemote}
+              onChange={(event) => setBooleanValue(setFormValues, "isRemote", event.target.checked)}
+            />
+          }
+          label="Remote"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={formValues.isHidden}
+              onChange={(event) => setBooleanValue(setFormValues, "isHidden", event.target.checked)}
+            />
+          }
+          label="Hidden"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={formValues.salaryIsPredicted ?? false}
+              onChange={(event) =>
+                setNullableBooleanValue(setFormValues, "salaryIsPredicted", event.target.checked)
+              }
+            />
+          }
+          label="Salary predicted"
+        />
+      </div>
+      <TextField
+        label="Posted at UTC"
+        value={formValues.postedAtUtc}
+        onChange={(event) => setStringValue(setFormValues, "postedAtUtc", event.target.value)}
+        fullWidth
+        required
+      />
+      <TextField
+        label="Imported at UTC"
+        value={formValues.importedAtUtc}
+        onChange={(event) => setStringValue(setFormValues, "importedAtUtc", event.target.value)}
+        fullWidth
+        required
+      />
+      <TextField
+        label="Last seen at UTC"
+        value={formValues.lastSeenAtUtc}
+        onChange={(event) => setStringValue(setFormValues, "lastSeenAtUtc", event.target.value)}
+        fullWidth
+        required
+      />
+    </JobFieldSection>
+  );
+}

--- a/apps/web/src/features/jobs/components/JobEditorForm.tsx
+++ b/apps/web/src/features/jobs/components/JobEditorForm.tsx
@@ -1,0 +1,56 @@
+import type { FormEvent } from "react";
+import type { CreateJobRequestDto } from "@/api/jobs/jobs.types";
+import { JobEditorActions } from "@/features/jobs/components/JobEditorActions";
+import { JobEditorClassificationSection } from "@/features/jobs/components/JobEditorClassificationSection";
+import { JobEditorCoreSection } from "@/features/jobs/components/JobEditorCoreSection";
+import { JobEditorFlagsSection } from "@/features/jobs/components/JobEditorFlagsSection";
+import {
+  type JobFormSetter
+} from "@/features/jobs/components/JobEditorFormState";
+import { JobEditorLocationSection } from "@/features/jobs/components/JobEditorLocationSection";
+import { JobEditorSourceSection } from "@/features/jobs/components/JobEditorSourceSection";
+
+type JobEditorFormProps = {
+  formValues: CreateJobRequestDto;
+  isAdmin: boolean;
+  isCreateMode: boolean;
+  isDeleting: boolean;
+  isHiding: boolean;
+  isSaving: boolean;
+  onDelete: () => void;
+  onHide: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  setFormValues: JobFormSetter;
+};
+
+export function JobEditorForm({
+  formValues,
+  isAdmin,
+  isCreateMode,
+  isDeleting,
+  isHiding,
+  isSaving,
+  onDelete,
+  onHide,
+  onSubmit,
+  setFormValues
+}: JobEditorFormProps) {
+  return (
+    <form onSubmit={onSubmit} className="mt-6 space-y-6">
+      <JobEditorCoreSection formValues={formValues} setFormValues={setFormValues} />
+      <JobEditorSourceSection formValues={formValues} setFormValues={setFormValues} />
+      <JobEditorLocationSection formValues={formValues} setFormValues={setFormValues} />
+      <JobEditorClassificationSection formValues={formValues} setFormValues={setFormValues} />
+      <JobEditorFlagsSection formValues={formValues} setFormValues={setFormValues} />
+      <JobEditorActions
+        isAdmin={isAdmin}
+        isCreateMode={isCreateMode}
+        isDeleting={isDeleting}
+        isHiding={isHiding}
+        isSaving={isSaving}
+        onDelete={onDelete}
+        onHide={onHide}
+      />
+    </form>
+  );
+}

--- a/apps/web/src/features/jobs/components/JobEditorFormState.ts
+++ b/apps/web/src/features/jobs/components/JobEditorFormState.ts
@@ -1,0 +1,59 @@
+import type { Dispatch, SetStateAction } from "react";
+import type { CreateJobRequestDto } from "@/api/jobs/jobs.types";
+
+export type JobFormSetter = Dispatch<SetStateAction<CreateJobRequestDto>>;
+
+export function setStringValue<TKey extends keyof CreateJobRequestDto>(
+  setFormValues: JobFormSetter,
+  key: TKey,
+  value: CreateJobRequestDto[TKey]
+) {
+  setFormValues((current) => ({
+    ...current,
+    [key]: value
+  }));
+}
+
+export function setNullableStringValue<TKey extends keyof CreateJobRequestDto>(
+  setFormValues: JobFormSetter,
+  key: TKey,
+  value: string
+) {
+  setFormValues((current) => ({
+    ...current,
+    [key]: value === "" ? null : value
+  }));
+}
+
+export function setNullableNumberValue<TKey extends keyof CreateJobRequestDto>(
+  setFormValues: JobFormSetter,
+  key: TKey,
+  value: string
+) {
+  setFormValues((current) => ({
+    ...current,
+    [key]: value === "" ? null : Number(value)
+  }));
+}
+
+export function setBooleanValue<TKey extends keyof CreateJobRequestDto>(
+  setFormValues: JobFormSetter,
+  key: TKey,
+  value: boolean
+) {
+  setFormValues((current) => ({
+    ...current,
+    [key]: value
+  }));
+}
+
+export function setNullableBooleanValue<TKey extends keyof CreateJobRequestDto>(
+  setFormValues: JobFormSetter,
+  key: TKey,
+  value: boolean
+) {
+  setFormValues((current) => ({
+    ...current,
+    [key]: value
+  }));
+}

--- a/apps/web/src/features/jobs/components/JobEditorHeader.tsx
+++ b/apps/web/src/features/jobs/components/JobEditorHeader.tsx
@@ -1,0 +1,40 @@
+import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
+import { Link } from "react-router-dom";
+
+type JobEditorHeaderProps = {
+  isCreateMode: boolean;
+  jobId: number | null;
+  pageTitle: string;
+};
+
+export function JobEditorHeader({ isCreateMode, jobId, pageTitle }: JobEditorHeaderProps) {
+  return (
+    <>
+      <Link
+        to="/admin/manage-jobs"
+        className="inline-flex items-center gap-2 text-sm text-foreground-secondary transition-colors hover:text-accent-primary"
+      >
+        <ArrowBackRoundedIcon sx={{ fontSize: 18 }} />
+        Back to jobs
+      </Link>
+
+      <div className="mt-6 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="font-mono text-xs tracking-[0.2em] text-foreground-tertiary">
+            BACKEND-ALIGNED JOB CONTRACT
+          </p>
+          <h1 className="mt-2 font-serif text-4xl font-semibold text-foreground">{pageTitle}</h1>
+          <p className="mt-3 max-w-3xl text-sm text-foreground-secondary">
+            This editor mirrors the backend jobs contract directly, including hide and delete
+            behavior enforced by the API.
+          </p>
+        </div>
+        {!isCreateMode ? (
+          <div className="rounded-lg border border-border bg-background-elevated px-4 py-3 text-sm text-foreground-secondary">
+            Resource ID <span className="font-medium text-foreground">{jobId}</span>
+          </div>
+        ) : null}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/features/jobs/components/JobEditorLocationSection.tsx
+++ b/apps/web/src/features/jobs/components/JobEditorLocationSection.tsx
@@ -1,0 +1,68 @@
+import { TextField } from "@mui/material";
+import type { CreateJobRequestDto } from "@/api/jobs/jobs.types";
+import { JobFieldSection } from "@/features/jobs/components/JobFieldSection";
+import {
+  setNullableNumberValue,
+  setNullableStringValue,
+  setStringValue,
+  type JobFormSetter
+} from "@/features/jobs/components/JobEditorFormState";
+
+type JobEditorLocationSectionProps = {
+  formValues: CreateJobRequestDto;
+  setFormValues: JobFormSetter;
+};
+
+export function JobEditorLocationSection({
+  formValues,
+  setFormValues
+}: JobEditorLocationSectionProps) {
+  return (
+    <JobFieldSection title="Location">
+      <TextField
+        label="Postcode"
+        value={formValues.postcode}
+        onChange={(event) => setStringValue(setFormValues, "postcode", event.target.value)}
+        fullWidth
+        required
+      />
+      <TextField
+        label="Location name"
+        value={formValues.locationName}
+        onChange={(event) => setStringValue(setFormValues, "locationName", event.target.value)}
+        fullWidth
+        required
+      />
+      <TextField
+        label="Location display name"
+        value={formValues.locationDisplayName ?? ""}
+        onChange={(event) =>
+          setNullableStringValue(setFormValues, "locationDisplayName", event.target.value)
+        }
+        fullWidth
+      />
+      <TextField
+        label="Location area JSON"
+        value={formValues.locationAreaJson ?? ""}
+        onChange={(event) =>
+          setNullableStringValue(setFormValues, "locationAreaJson", event.target.value)
+        }
+        fullWidth
+      />
+      <TextField
+        label="Latitude"
+        value={formValues.latitude ?? ""}
+        onChange={(event) => setNullableNumberValue(setFormValues, "latitude", event.target.value)}
+        fullWidth
+      />
+      <TextField
+        label="Longitude"
+        value={formValues.longitude ?? ""}
+        onChange={(event) =>
+          setNullableNumberValue(setFormValues, "longitude", event.target.value)
+        }
+        fullWidth
+      />
+    </JobFieldSection>
+  );
+}

--- a/apps/web/src/features/jobs/components/JobEditorSourceSection.tsx
+++ b/apps/web/src/features/jobs/components/JobEditorSourceSection.tsx
@@ -1,0 +1,63 @@
+import { TextField } from "@mui/material";
+import type { CreateJobRequestDto } from "@/api/jobs/jobs.types";
+import { JobFieldSection } from "@/features/jobs/components/JobFieldSection";
+import {
+  setNullableNumberValue,
+  setNullableStringValue,
+  setStringValue,
+  type JobFormSetter
+} from "@/features/jobs/components/JobEditorFormState";
+
+type JobEditorSourceSectionProps = {
+  formValues: CreateJobRequestDto;
+  setFormValues: JobFormSetter;
+};
+
+export function JobEditorSourceSection({
+  formValues,
+  setFormValues
+}: JobEditorSourceSectionProps) {
+  return (
+    <JobFieldSection title="Source">
+      <TextField
+        label="Source name"
+        value={formValues.sourceName}
+        onChange={(event) => setStringValue(setFormValues, "sourceName", event.target.value)}
+        fullWidth
+        required
+      />
+      <TextField
+        label="Source job ID"
+        value={formValues.sourceJobId}
+        onChange={(event) => setStringValue(setFormValues, "sourceJobId", event.target.value)}
+        fullWidth
+        required
+      />
+      <TextField
+        label="Source ad reference"
+        value={formValues.sourceAdReference ?? ""}
+        onChange={(event) =>
+          setNullableStringValue(setFormValues, "sourceAdReference", event.target.value)
+        }
+        fullWidth
+      />
+      <TextField
+        label="Job refresh run ID"
+        value={formValues.jobRefreshRunId ?? ""}
+        onChange={(event) =>
+          setNullableNumberValue(setFormValues, "jobRefreshRunId", event.target.value)
+        }
+        fullWidth
+      />
+      <TextField
+        label="Raw payload JSON"
+        value={formValues.rawPayloadJson}
+        onChange={(event) => setStringValue(setFormValues, "rawPayloadJson", event.target.value)}
+        fullWidth
+        required
+        multiline
+        minRows={4}
+      />
+    </JobFieldSection>
+  );
+}

--- a/apps/web/src/features/jobs/components/JobFieldSection.tsx
+++ b/apps/web/src/features/jobs/components/JobFieldSection.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+import { SectionCard } from "@/components/SectionCard";
+
+type JobFieldSectionProps = {
+  children: ReactNode;
+  title: string;
+};
+
+export function JobFieldSection({ children, title }: JobFieldSectionProps) {
+  return (
+    <SectionCard className="p-6">
+      <h2 className="font-serif text-2xl font-semibold text-foreground">{title}</h2>
+      <div className="mt-5 grid gap-4 md:grid-cols-2">{children}</div>
+    </SectionCard>
+  );
+}

--- a/apps/web/src/features/jobs/components/JobsManagementHeader.tsx
+++ b/apps/web/src/features/jobs/components/JobsManagementHeader.tsx
@@ -1,0 +1,23 @@
+type JobsManagementHeaderProps = {
+  totalCount: number;
+};
+
+export function JobsManagementHeader({ totalCount }: JobsManagementHeaderProps) {
+  return (
+    <div className="mb-6 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+      <div>
+        <p className="font-mono text-xs tracking-[0.2em] text-foreground-tertiary">
+          ADMIN JOB MANAGEMENT
+        </p>
+        <h1 className="mt-2 font-serif text-4xl font-semibold text-foreground">Manage jobs</h1>
+        <p className="mt-3 max-w-3xl text-base text-foreground-secondary">
+          Browse more jobs in one screen, filter from the top toolbar, and use bulk hide or
+          delete actions backed by the batch admin APIs.
+        </p>
+      </div>
+      <div className="rounded-lg border border-border bg-background-elevated px-4 py-3 text-sm text-foreground-secondary">
+        <span className="font-medium text-foreground">{totalCount}</span> total jobs
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/jobs/components/JobsManagementTable.tsx
+++ b/apps/web/src/features/jobs/components/JobsManagementTable.tsx
@@ -1,0 +1,181 @@
+import { Checkbox, Chip, Table, TableBody, TableCell, TableContainer, TableHead, TablePagination, TableRow } from "@mui/material";
+import type { JobDetailsResponseDto } from "@/api/jobs/jobs.types";
+
+type JobsManagementTableProps = {
+  jobs: JobDetailsResponseDto[];
+  pageIndex: number;
+  pageSize: number;
+  selectedIds: number[];
+  totalCount: number;
+  onOpenJob: (jobId: number) => void;
+  onPageChange: (pageIndex: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
+  onSelectAll: (checked: boolean) => void;
+  onSelectJob: (jobId: number, checked: boolean) => void;
+};
+
+export function JobsManagementTable({
+  jobs,
+  pageIndex,
+  pageSize,
+  selectedIds,
+  totalCount,
+  onOpenJob,
+  onPageChange,
+  onPageSizeChange,
+  onSelectAll,
+  onSelectJob
+}: JobsManagementTableProps) {
+  const selectedVisibleCount = jobs.filter((job) => selectedIds.includes(job.id)).length;
+  const allVisibleSelected = jobs.length > 0 && selectedVisibleCount === jobs.length;
+
+  return (
+    <>
+      <TableContainer>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell padding="checkbox">
+                <Checkbox
+                  checked={allVisibleSelected}
+                  indeterminate={selectedVisibleCount > 0 && !allVisibleSelected}
+                  onChange={(event) => onSelectAll(event.target.checked)}
+                  inputProps={{ "aria-label": "Select all jobs" }}
+                />
+              </TableCell>
+              <TableCell>Title</TableCell>
+              <TableCell>Company</TableCell>
+              <TableCell>Location</TableCell>
+              <TableCell>Source</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Posted</TableCell>
+              <TableCell>Type</TableCell>
+              <TableCell align="right">Salary</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {jobs.map((job) => {
+              const isSelected = selectedIds.includes(job.id);
+
+              return (
+                <TableRow
+                  key={job.id}
+                  hover
+                  selected={isSelected}
+                  onClick={() => onOpenJob(job.id)}
+                  sx={{ cursor: "pointer" }}
+                >
+                  <TableCell
+                    padding="checkbox"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                    }}
+                  >
+                    <Checkbox
+                      checked={isSelected}
+                      onChange={(event) => onSelectJob(job.id, event.target.checked)}
+                      inputProps={{ "aria-label": `Select job ${job.id}` }}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <div className="max-w-[280px]">
+                      <div className="font-medium text-foreground">{job.title}</div>
+                      <div className="mt-1 truncate text-xs text-foreground-tertiary">
+                        #{job.id} · {job.sourceJobId}
+                      </div>
+                    </div>
+                  </TableCell>
+                  <TableCell>{job.companyDisplayName ?? job.company}</TableCell>
+                  <TableCell>
+                    <div className="max-w-[180px] truncate">
+                      {job.locationDisplayName ?? job.locationName}
+                    </div>
+                  </TableCell>
+                  <TableCell>{job.sourceName}</TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-1">
+                      {job.isHidden ? (
+                        <Chip size="small" label="Hidden" color="warning" variant="outlined" />
+                      ) : (
+                        <Chip size="small" label="Visible" color="success" variant="outlined" />
+                      )}
+                      {job.isRemote ? <Chip size="small" label="Remote" variant="outlined" /> : null}
+                    </div>
+                  </TableCell>
+                  <TableCell>{formatDate(job.postedAtUtc)}</TableCell>
+                  <TableCell>{formatJobType(job)}</TableCell>
+                  <TableCell align="right">{formatSalary(job)}</TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <TablePagination
+        component="div"
+        count={totalCount}
+        page={pageIndex}
+        onPageChange={(_, nextPage) => onPageChange(nextPage)}
+        rowsPerPage={pageSize}
+        onRowsPerPageChange={(event) => onPageSizeChange(Number(event.target.value))}
+        rowsPerPageOptions={[20, 50, 100]}
+      />
+    </>
+  );
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Unknown";
+  }
+
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric"
+  }).format(date);
+}
+
+function formatSalary(job: JobDetailsResponseDto): string {
+  if (job.salaryMin === null && job.salaryMax === null) {
+    return "N/A";
+  }
+
+  const formatter = new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: job.salaryCurrency ?? "GBP",
+    maximumFractionDigits: 0
+  });
+
+  if (job.salaryMin !== null && job.salaryMax !== null) {
+    return `${formatter.format(job.salaryMin)} - ${formatter.format(job.salaryMax)}`;
+  }
+
+  return formatter.format(job.salaryMin ?? job.salaryMax ?? 0);
+}
+
+function formatJobType(job: JobDetailsResponseDto): string {
+  if (job.contractType) {
+    return job.contractType.replaceAll("_", " ");
+  }
+
+  if (job.isPermanent) {
+    return "permanent";
+  }
+
+  if (job.isContract) {
+    return "contract";
+  }
+
+  if (job.isFullTime) {
+    return "full time";
+  }
+
+  if (job.isPartTime) {
+    return "part time";
+  }
+
+  return "unspecified";
+}

--- a/apps/web/src/features/jobs/components/JobsManagementToolbar.tsx
+++ b/apps/web/src/features/jobs/components/JobsManagementToolbar.tsx
@@ -1,0 +1,159 @@
+import FilterListRoundedIcon from "@mui/icons-material/FilterListRounded";
+import VisibilityOffRoundedIcon from "@mui/icons-material/VisibilityOffRounded";
+import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
+import { Button, MenuItem, TextField } from "@mui/material";
+
+export type VisibilityFilter = "visible" | "hidden" | "all";
+
+export type JobsListFilters = {
+  keyword: string;
+  company: string;
+  postcode: string;
+  location: string;
+  sourceName: string;
+  categoryTag: string;
+  visibility: VisibilityFilter;
+};
+
+type JobsManagementToolbarProps = {
+  draftFilters: JobsListFilters;
+  isAdmin: boolean;
+  isProcessing: boolean;
+  selectionSummary: string;
+  selectedCount: number;
+  onApplyFilters: () => void;
+  onDeleteSelected: () => void;
+  onFiltersChange: (filters: JobsListFilters) => void;
+  onHideSelected: () => void;
+  onResetFilters: () => void;
+};
+
+export function JobsManagementToolbar({
+  draftFilters,
+  isAdmin,
+  isProcessing,
+  selectionSummary,
+  selectedCount,
+  onApplyFilters,
+  onDeleteSelected,
+  onFiltersChange,
+  onHideSelected,
+  onResetFilters
+}: JobsManagementToolbarProps) {
+  return (
+    <div className="border-b border-divider p-5">
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex items-center gap-2">
+            <FilterListRoundedIcon className="text-foreground-tertiary" />
+            <h2 className="font-serif text-2xl font-semibold text-foreground">Job table</h2>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="text-sm text-foreground-secondary">{selectionSummary}</span>
+            <Button
+              variant="outlined"
+              color="inherit"
+              startIcon={<VisibilityOffRoundedIcon />}
+              disabled={!isAdmin || selectedCount === 0 || isProcessing}
+              onClick={onHideSelected}
+            >
+              {isProcessing ? "Working..." : "Hide selected"}
+            </Button>
+            <Button
+              variant="outlined"
+              color="error"
+              startIcon={<DeleteOutlineRoundedIcon />}
+              disabled={!isAdmin || selectedCount === 0 || isProcessing}
+              onClick={onDeleteSelected}
+            >
+              {isProcessing ? "Working..." : "Delete selected"}
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-3 xl:grid-cols-7">
+          <TextField
+            label="Keyword"
+            size="small"
+            value={draftFilters.keyword}
+            onChange={(event) =>
+              onFiltersChange({ ...draftFilters, keyword: event.target.value })
+            }
+          />
+          <TextField
+            label="Company"
+            size="small"
+            value={draftFilters.company}
+            onChange={(event) =>
+              onFiltersChange({ ...draftFilters, company: event.target.value })
+            }
+          />
+          <TextField
+            label="Postcode"
+            size="small"
+            value={draftFilters.postcode}
+            onChange={(event) =>
+              onFiltersChange({ ...draftFilters, postcode: event.target.value })
+            }
+          />
+          <TextField
+            label="Location"
+            size="small"
+            value={draftFilters.location}
+            onChange={(event) =>
+              onFiltersChange({ ...draftFilters, location: event.target.value })
+            }
+          />
+          <TextField
+            label="Source"
+            size="small"
+            value={draftFilters.sourceName}
+            onChange={(event) =>
+              onFiltersChange({ ...draftFilters, sourceName: event.target.value })
+            }
+          />
+          <TextField
+            label="Category"
+            size="small"
+            value={draftFilters.categoryTag}
+            onChange={(event) =>
+              onFiltersChange({ ...draftFilters, categoryTag: event.target.value })
+            }
+          />
+          <TextField
+            select
+            label="Visibility"
+            size="small"
+            value={draftFilters.visibility}
+            onChange={(event) =>
+              onFiltersChange({
+                ...draftFilters,
+                visibility: event.target.value as VisibilityFilter
+              })
+            }
+          >
+            <MenuItem value="visible">Visible</MenuItem>
+            <MenuItem value="hidden">Hidden</MenuItem>
+            <MenuItem value="all">All</MenuItem>
+          </TextField>
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          <Button
+            variant="contained"
+            onClick={onApplyFilters}
+            sx={{
+              bgcolor: "accent.main",
+              "&:hover": { bgcolor: "accent.dark" }
+            }}
+          >
+            Apply filters
+          </Button>
+          <Button variant="outlined" color="inherit" onClick={onResetFilters}>
+            Reset
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/jobs/views/JobsListView.test.tsx
+++ b/apps/web/src/features/jobs/views/JobsListView.test.tsx
@@ -112,5 +112,5 @@ describe("JobsListView", () => {
         isHidden: false
       })
     );
-  });
+  }, 10000);
 });

--- a/apps/web/src/features/jobs/views/JobsListView.test.tsx
+++ b/apps/web/src/features/jobs/views/JobsListView.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { theme } from "@/app/theme";
+import { getJobsPage, hideJobs } from "@/api/jobs/jobs.api";
+import { JobsListView } from "@/features/jobs/views/JobsListView";
+import { useSessionStore } from "@/store/session.store";
+
+vi.mock("@/api/jobs/jobs.api", () => ({
+  deleteJobs: vi.fn(),
+  getJobsPage: vi.fn(),
+  hideJobs: vi.fn()
+}));
+
+describe("JobsListView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSessionStore.setState({
+      user: {
+        userAccount: "admin",
+        displayName: "Admin",
+        role: "admin",
+        email: "admin@example.com"
+      },
+      isAuthenticated: true
+    });
+  });
+
+  it("loads jobs into the admin table and can hide selected rows", async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(getJobsPage).mockResolvedValue({
+      pageIndex: 0,
+      pageSize: 20,
+      totalCount: 1,
+      items: [
+        {
+          id: 42,
+          jobRefreshRunId: null,
+          sourceName: "Adzuna",
+          sourceJobId: "adz-42",
+          sourceAdReference: null,
+          title: "Senior Frontend Engineer",
+          description: "Build the web application.",
+          summary: "Build the web application.",
+          url: "https://example.com/jobs/42",
+          company: "Firefly",
+          companyDisplayName: "Firefly",
+          companyCanonicalName: "firefly",
+          postcode: "EC2A 4NE",
+          locationName: "London",
+          locationDisplayName: "London",
+          locationAreaJson: "[\"London\"]",
+          latitude: null,
+          longitude: null,
+          categoryTag: "it-jobs",
+          categoryLabel: "IT jobs",
+          salaryMin: 75000,
+          salaryMax: 95000,
+          salaryCurrency: "GBP",
+          salaryIsPredicted: false,
+          contractTime: "full_time",
+          contractType: "permanent",
+          isFullTime: true,
+          isPartTime: false,
+          isPermanent: true,
+          isContract: false,
+          isRemote: true,
+          postedAtUtc: "2025-04-03T10:00:00Z",
+          importedAtUtc: "2025-04-03T12:00:00Z",
+          lastSeenAtUtc: "2025-04-03T12:00:00Z",
+          isHidden: false,
+          rawPayloadJson: "{}"
+        }
+      ]
+    });
+
+    render(
+      <ThemeProvider theme={theme}>
+        <MemoryRouter initialEntries={["/admin/manage-jobs"]}>
+          <JobsListView />
+        </MemoryRouter>
+      </ThemeProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Senior Frontend Engineer")).toBeInTheDocument();
+    });
+
+    vi.mocked(hideJobs).mockResolvedValueOnce({
+      hiddenCount: 1,
+      hiddenIds: [42],
+      missingIds: []
+    });
+
+    await user.click(screen.getByRole("checkbox", { name: "Select job 42" }));
+    await user.click(screen.getByRole("button", { name: "Hide selected" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("1 jobs hidden successfully.")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/total jobs/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Manage jobs" })).toBeInTheDocument();
+    expect(hideJobs).toHaveBeenCalledWith([42]);
+    expect(getJobsPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pageIndex: 0,
+        pageSize: 20,
+        isHidden: false
+      })
+    );
+  });
+});

--- a/apps/web/src/features/jobs/views/JobsListView.tsx
+++ b/apps/web/src/features/jobs/views/JobsListView.tsx
@@ -1,0 +1,542 @@
+import AddRoundedIcon from "@mui/icons-material/AddRounded";
+import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
+import FilterListRoundedIcon from "@mui/icons-material/FilterListRounded";
+import VisibilityOffRoundedIcon from "@mui/icons-material/VisibilityOffRounded";
+import WorkOutlineRoundedIcon from "@mui/icons-material/WorkOutlineRounded";
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Chip,
+  MenuItem,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  TextField
+} from "@mui/material";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { AppHeader } from "@/components/AppHeader";
+import { SectionCard } from "@/components/SectionCard";
+import { deleteJobs, getJobsPage, hideJobs } from "@/api/jobs/jobs.api";
+import type { DeleteJobsResponseDto, JobDetailsResponseDto } from "@/api/jobs/jobs.types";
+import { useAsyncTask } from "@/lib/async/useAsyncTask";
+import { useSessionStore } from "@/store/session.store";
+
+type VisibilityFilter = "visible" | "hidden" | "all";
+
+type JobsListFilters = {
+  keyword: string;
+  company: string;
+  postcode: string;
+  location: string;
+  sourceName: string;
+  categoryTag: string;
+  visibility: VisibilityFilter;
+};
+
+const emptyFilters: JobsListFilters = {
+  keyword: "",
+  company: "",
+  postcode: "",
+  location: "",
+  sourceName: "",
+  categoryTag: "",
+  visibility: "visible"
+};
+
+const pageSize = 20;
+
+export function JobsListView() {
+  const navigate = useNavigate();
+  const user = useSessionStore((state) => state.user);
+  const isAdmin = user?.role === "admin";
+  const [draftFilters, setDraftFilters] = useState<JobsListFilters>(emptyFilters);
+  const [filters, setFilters] = useState<JobsListFilters>(emptyFilters);
+  const [pageIndex, setPageIndex] = useState(0);
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const loadJobs = useCallback(async (nextPageIndex: number, nextFilters: JobsListFilters) => {
+    return getJobsPage({
+      pageIndex: nextPageIndex,
+      pageSize,
+      keyword: normalizeText(nextFilters.keyword),
+      company: normalizeText(nextFilters.company),
+      postcode: normalizeText(nextFilters.postcode),
+      location: normalizeText(nextFilters.location),
+      sourceName: normalizeText(nextFilters.sourceName),
+      categoryTag: normalizeText(nextFilters.categoryTag),
+      isHidden: mapVisibilityToHiddenFlag(nextFilters.visibility)
+    });
+  }, []);
+
+  const { status, data, errorMessage, execute } = useAsyncTask(loadJobs);
+
+  useEffect(() => {
+    void execute(pageIndex, filters);
+  }, [execute, filters, pageIndex]);
+
+  useEffect(() => {
+    const visibleIds = new Set((data?.items ?? []).map((job) => job.id));
+    setSelectedIds((current) => current.filter((id) => visibleIds.has(id)));
+  }, [data]);
+
+  const jobs = data?.items ?? [];
+  const viewStatus = status === "success" && jobs.length === 0 ? "empty" : status;
+  const totalCount = data?.totalCount ?? 0;
+  const selectedVisibleCount = jobs.filter((job) => selectedIds.includes(job.id)).length;
+  const allVisibleSelected = jobs.length > 0 && selectedVisibleCount === jobs.length;
+
+  const selectionSummary = useMemo(() => {
+    if (selectedIds.length === 0) {
+      return "No jobs selected";
+    }
+
+    return `${selectedIds.length} selected`;
+  }, [selectedIds]);
+
+  async function handleHideSelected() {
+    if (!isAdmin || selectedIds.length === 0) {
+      return;
+    }
+
+    setIsProcessing(true);
+    setActionMessage(null);
+    setActionError(null);
+
+    try {
+      const result = await hideJobs(selectedIds);
+      setActionMessage(buildHideSummary(result.hiddenCount, result.missingIds.length));
+      setSelectedIds([]);
+      await execute(pageIndex, filters);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Unable to hide the selected jobs.");
+    } finally {
+      setIsProcessing(false);
+    }
+  }
+
+  async function handleDeleteSelected() {
+    if (!isAdmin || selectedIds.length === 0) {
+      return;
+    }
+
+    if (!window.confirm("Delete the selected jobs? Any visible jobs will be rejected by the backend until they are hidden.")) {
+      return;
+    }
+
+    setIsProcessing(true);
+    setActionMessage(null);
+    setActionError(null);
+
+    try {
+      const result = await deleteJobs(selectedIds);
+      setActionMessage(buildDeleteSummary(result));
+      setSelectedIds([]);
+      await execute(pageIndex, filters);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Unable to delete the selected jobs.");
+    } finally {
+      setIsProcessing(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <AppHeader
+        variant="authenticated"
+        actions={
+          isAdmin ? (
+            <Button
+              onClick={() => void navigate("/admin/manage-jobs/new")}
+              variant="contained"
+              startIcon={<AddRoundedIcon />}
+              sx={{
+                bgcolor: "accent.main",
+                "&:hover": { bgcolor: "accent.dark" }
+              }}
+            >
+              New job
+            </Button>
+          ) : null
+        }
+      />
+
+      <div className="mx-auto max-w-[1400px] px-5 py-8 sm:px-8">
+        <div className="mb-6 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="font-mono text-xs tracking-[0.2em] text-foreground-tertiary">
+              ADMIN JOB MANAGEMENT
+            </p>
+            <h1 className="mt-2 font-serif text-4xl font-semibold text-foreground">
+              Manage jobs
+            </h1>
+            <p className="mt-3 max-w-3xl text-base text-foreground-secondary">
+              Browse more jobs in one screen, filter from the top toolbar, and use bulk hide or
+              delete actions backed by the batch admin APIs.
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-background-elevated px-4 py-3 text-sm text-foreground-secondary">
+            <span className="font-medium text-foreground">{totalCount}</span> total jobs
+          </div>
+        </div>
+
+        {!isAdmin ? (
+          <Alert severity="warning" sx={{ mb: 4 }}>
+            This route is intended for admin job management. Your session can read jobs, but batch
+            hide, batch delete, and edit actions require the admin role from the backend API.
+          </Alert>
+        ) : null}
+
+        {actionMessage ? <Alert severity="success" sx={{ mb: 3 }}>{actionMessage}</Alert> : null}
+        {actionError ? <Alert severity="error" sx={{ mb: 3 }}>{actionError}</Alert> : null}
+        {viewStatus === "error" ? (
+          <Alert severity="error" sx={{ mb: 3 }}>
+            {errorMessage ?? "Unable to load jobs."}
+          </Alert>
+        ) : null}
+
+        <SectionCard className="overflow-hidden">
+          <div className="border-b border-divider p-5">
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                <div className="flex items-center gap-2">
+                  <FilterListRoundedIcon className="text-foreground-tertiary" />
+                  <h2 className="font-serif text-2xl font-semibold text-foreground">Job table</h2>
+                </div>
+                <div className="flex flex-wrap items-center gap-3">
+                  <span className="text-sm text-foreground-secondary">{selectionSummary}</span>
+                  <Button
+                    variant="outlined"
+                    color="inherit"
+                    startIcon={<VisibilityOffRoundedIcon />}
+                    disabled={!isAdmin || selectedIds.length === 0 || isProcessing}
+                    onClick={() => void handleHideSelected()}
+                  >
+                    {isProcessing ? "Working..." : "Hide selected"}
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    color="error"
+                    startIcon={<DeleteOutlineRoundedIcon />}
+                    disabled={!isAdmin || selectedIds.length === 0 || isProcessing}
+                    onClick={() => void handleDeleteSelected()}
+                  >
+                    {isProcessing ? "Working..." : "Delete selected"}
+                  </Button>
+                </div>
+              </div>
+
+              <div className="grid gap-3 md:grid-cols-3 xl:grid-cols-7">
+                <TextField
+                  label="Keyword"
+                  size="small"
+                  value={draftFilters.keyword}
+                  onChange={(event) =>
+                    setDraftFilters((current) => ({ ...current, keyword: event.target.value }))
+                  }
+                />
+                <TextField
+                  label="Company"
+                  size="small"
+                  value={draftFilters.company}
+                  onChange={(event) =>
+                    setDraftFilters((current) => ({ ...current, company: event.target.value }))
+                  }
+                />
+                <TextField
+                  label="Postcode"
+                  size="small"
+                  value={draftFilters.postcode}
+                  onChange={(event) =>
+                    setDraftFilters((current) => ({ ...current, postcode: event.target.value }))
+                  }
+                />
+                <TextField
+                  label="Location"
+                  size="small"
+                  value={draftFilters.location}
+                  onChange={(event) =>
+                    setDraftFilters((current) => ({ ...current, location: event.target.value }))
+                  }
+                />
+                <TextField
+                  label="Source"
+                  size="small"
+                  value={draftFilters.sourceName}
+                  onChange={(event) =>
+                    setDraftFilters((current) => ({ ...current, sourceName: event.target.value }))
+                  }
+                />
+                <TextField
+                  label="Category"
+                  size="small"
+                  value={draftFilters.categoryTag}
+                  onChange={(event) =>
+                    setDraftFilters((current) => ({ ...current, categoryTag: event.target.value }))
+                  }
+                />
+                <TextField
+                  select
+                  label="Visibility"
+                  size="small"
+                  value={draftFilters.visibility}
+                  onChange={(event) =>
+                    setDraftFilters((current) => ({
+                      ...current,
+                      visibility: event.target.value as VisibilityFilter
+                    }))
+                  }
+                >
+                  <MenuItem value="visible">Visible</MenuItem>
+                  <MenuItem value="hidden">Hidden</MenuItem>
+                  <MenuItem value="all">All</MenuItem>
+                </TextField>
+              </div>
+
+              <div className="flex flex-wrap gap-3">
+                <Button
+                  variant="contained"
+                  onClick={() => {
+                    setPageIndex(0);
+                    setFilters(draftFilters);
+                  }}
+                  sx={{
+                    bgcolor: "accent.main",
+                    "&:hover": { bgcolor: "accent.dark" }
+                  }}
+                >
+                  Apply filters
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="inherit"
+                  onClick={() => {
+                    setDraftFilters(emptyFilters);
+                    setPageIndex(0);
+                    setFilters(emptyFilters);
+                  }}
+                >
+                  Reset
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          {viewStatus === "loading" ? (
+            <div className="p-6 text-sm text-foreground-secondary">Loading jobs from the API...</div>
+          ) : null}
+
+          {viewStatus === "empty" ? (
+            <div className="p-10 text-center">
+              <WorkOutlineRoundedIcon className="mx-auto text-4xl text-foreground-tertiary" />
+              <h3 className="mt-4 font-serif text-2xl font-semibold text-foreground">
+                No jobs matched those filters
+              </h3>
+              <p className="mt-3 text-sm text-foreground-secondary">
+                Broaden the filters or add a new job resource.
+              </p>
+            </div>
+          ) : null}
+
+          {jobs.length > 0 ? (
+            <>
+              <TableContainer>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell padding="checkbox">
+                        <Checkbox
+                          checked={allVisibleSelected}
+                          indeterminate={selectedVisibleCount > 0 && !allVisibleSelected}
+                          onChange={(event) =>
+                            setSelectedIds(event.target.checked ? jobs.map((job) => job.id) : [])
+                          }
+                          inputProps={{ "aria-label": "Select all jobs" }}
+                        />
+                      </TableCell>
+                      <TableCell>Title</TableCell>
+                      <TableCell>Company</TableCell>
+                      <TableCell>Location</TableCell>
+                      <TableCell>Source</TableCell>
+                      <TableCell>Status</TableCell>
+                      <TableCell>Posted</TableCell>
+                      <TableCell>Type</TableCell>
+                      <TableCell align="right">Salary</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {jobs.map((job) => {
+                      const isSelected = selectedIds.includes(job.id);
+
+                      return (
+                        <TableRow
+                          key={job.id}
+                          hover
+                          selected={isSelected}
+                          onClick={() => void navigate(`/admin/manage-jobs/${job.id}`)}
+                          sx={{ cursor: "pointer" }}
+                        >
+                          <TableCell
+                            padding="checkbox"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                            }}
+                          >
+                            <Checkbox
+                              checked={isSelected}
+                              onChange={(event) => {
+                                setSelectedIds((current) =>
+                                  event.target.checked
+                                    ? [...current, job.id]
+                                    : current.filter((id) => id !== job.id)
+                                );
+                              }}
+                              inputProps={{ "aria-label": `Select job ${job.id}` }}
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <div className="max-w-[280px]">
+                              <div className="font-medium text-foreground">{job.title}</div>
+                              <div className="mt-1 truncate text-xs text-foreground-tertiary">
+                                #{job.id} · {job.sourceJobId}
+                              </div>
+                            </div>
+                          </TableCell>
+                          <TableCell>{job.companyDisplayName ?? job.company}</TableCell>
+                          <TableCell>
+                            <div className="max-w-[180px] truncate">
+                              {job.locationDisplayName ?? job.locationName}
+                            </div>
+                          </TableCell>
+                          <TableCell>{job.sourceName}</TableCell>
+                          <TableCell>
+                            <div className="flex flex-wrap gap-1">
+                              {job.isHidden ? (
+                                <Chip size="small" label="Hidden" color="warning" variant="outlined" />
+                              ) : (
+                                <Chip size="small" label="Visible" color="success" variant="outlined" />
+                              )}
+                              {job.isRemote ? <Chip size="small" label="Remote" variant="outlined" /> : null}
+                            </div>
+                          </TableCell>
+                          <TableCell>{formatDate(job.postedAtUtc)}</TableCell>
+                          <TableCell>{formatJobType(job)}</TableCell>
+                          <TableCell align="right">{formatSalary(job)}</TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+
+              <TablePagination
+                component="div"
+                count={totalCount}
+                page={pageIndex}
+                onPageChange={(_, nextPage) => setPageIndex(nextPage)}
+                rowsPerPage={pageSize}
+                rowsPerPageOptions={[pageSize]}
+              />
+            </>
+          ) : null}
+        </SectionCard>
+      </div>
+    </div>
+  );
+}
+
+function mapVisibilityToHiddenFlag(value: VisibilityFilter): boolean | undefined {
+  if (value === "all") {
+    return undefined;
+  }
+
+  return value === "hidden";
+}
+
+function normalizeText(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Unknown";
+  }
+
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric"
+  }).format(date);
+}
+
+function formatSalary(job: JobDetailsResponseDto): string {
+  if (job.salaryMin === null && job.salaryMax === null) {
+    return "N/A";
+  }
+
+  const formatter = new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: job.salaryCurrency ?? "GBP",
+    maximumFractionDigits: 0
+  });
+
+  if (job.salaryMin !== null && job.salaryMax !== null) {
+    return `${formatter.format(job.salaryMin)} - ${formatter.format(job.salaryMax)}`;
+  }
+
+  return formatter.format(job.salaryMin ?? job.salaryMax ?? 0);
+}
+
+function formatJobType(job: JobDetailsResponseDto): string {
+  if (job.contractType) {
+    return job.contractType.replaceAll("_", " ");
+  }
+
+  if (job.isPermanent) {
+    return "permanent";
+  }
+
+  if (job.isContract) {
+    return "contract";
+  }
+
+  if (job.isFullTime) {
+    return "full time";
+  }
+
+  if (job.isPartTime) {
+    return "part time";
+  }
+
+  return "unspecified";
+}
+
+function buildHideSummary(hiddenCount: number, missingCount: number): string {
+  if (missingCount > 0) {
+    return `${hiddenCount} jobs hidden. ${missingCount} ids were missing.`;
+  }
+
+  return `${hiddenCount} jobs hidden successfully.`;
+}
+
+function buildDeleteSummary(result: DeleteJobsResponseDto): string {
+  if (result.notHiddenIds.length > 0) {
+    return `${result.deletedCount} jobs deleted. ${result.notHiddenIds.length} selected jobs still need to be hidden first.`;
+  }
+
+  if (result.missingIds.length > 0) {
+    return `${result.deletedCount} jobs deleted. ${result.missingIds.length} ids were missing.`;
+  }
+
+  return `${result.deletedCount} jobs deleted successfully.`;
+}

--- a/apps/web/src/features/jobs/views/JobsListView.tsx
+++ b/apps/web/src/features/jobs/views/JobsListView.tsx
@@ -1,43 +1,21 @@
 import AddRoundedIcon from "@mui/icons-material/AddRounded";
-import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
-import FilterListRoundedIcon from "@mui/icons-material/FilterListRounded";
-import VisibilityOffRoundedIcon from "@mui/icons-material/VisibilityOffRounded";
 import WorkOutlineRoundedIcon from "@mui/icons-material/WorkOutlineRounded";
-import {
-  Alert,
-  Button,
-  Checkbox,
-  Chip,
-  MenuItem,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TablePagination,
-  TableRow,
-  TextField
-} from "@mui/material";
+import { Alert, Button } from "@mui/material";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppHeader } from "@/components/AppHeader";
 import { SectionCard } from "@/components/SectionCard";
 import { deleteJobs, getJobsPage, hideJobs } from "@/api/jobs/jobs.api";
-import type { DeleteJobsResponseDto, JobDetailsResponseDto } from "@/api/jobs/jobs.types";
+import type { DeleteJobsResponseDto } from "@/api/jobs/jobs.types";
+import { JobsManagementHeader } from "@/features/jobs/components/JobsManagementHeader";
+import {
+  JobsManagementToolbar,
+  type JobsListFilters,
+  type VisibilityFilter
+} from "@/features/jobs/components/JobsManagementToolbar";
+import { JobsManagementTable } from "@/features/jobs/components/JobsManagementTable";
 import { useAsyncTask } from "@/lib/async/useAsyncTask";
 import { useSessionStore } from "@/store/session.store";
-
-type VisibilityFilter = "visible" | "hidden" | "all";
-
-type JobsListFilters = {
-  keyword: string;
-  company: string;
-  postcode: string;
-  location: string;
-  sourceName: string;
-  categoryTag: string;
-  visibility: VisibilityFilter;
-};
 
 const emptyFilters: JobsListFilters = {
   keyword: "",
@@ -96,8 +74,6 @@ export function JobsListView() {
   const jobs = data?.items ?? [];
   const viewStatus = status === "success" && jobs.length === 0 ? "empty" : status;
   const totalCount = data?.totalCount ?? 0;
-  const selectedVisibleCount = jobs.filter((job) => selectedIds.includes(job.id)).length;
-  const allVisibleSelected = jobs.length > 0 && selectedVisibleCount === jobs.length;
 
   const selectionSummary = useMemo(() => {
     if (selectedIds.length === 0) {
@@ -175,23 +151,7 @@ export function JobsListView() {
       />
 
       <div className="mx-auto max-w-[1400px] px-5 py-8 sm:px-8">
-        <div className="mb-6 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-          <div>
-            <p className="font-mono text-xs tracking-[0.2em] text-foreground-tertiary">
-              ADMIN JOB MANAGEMENT
-            </p>
-            <h1 className="mt-2 font-serif text-4xl font-semibold text-foreground">
-              Manage jobs
-            </h1>
-            <p className="mt-3 max-w-3xl text-base text-foreground-secondary">
-              Browse more jobs in one screen, filter from the top toolbar, and use bulk hide or
-              delete actions backed by the batch admin APIs.
-            </p>
-          </div>
-          <div className="rounded-lg border border-border bg-background-elevated px-4 py-3 text-sm text-foreground-secondary">
-            <span className="font-medium text-foreground">{totalCount}</span> total jobs
-          </div>
-        </div>
+        <JobsManagementHeader totalCount={totalCount} />
 
         {!isAdmin ? (
           <Alert severity="warning" sx={{ mb: 4 }}>
@@ -209,131 +169,25 @@ export function JobsListView() {
         ) : null}
 
         <SectionCard className="overflow-hidden">
-          <div className="border-b border-divider p-5">
-            <div className="flex flex-col gap-4">
-              <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-                <div className="flex items-center gap-2">
-                  <FilterListRoundedIcon className="text-foreground-tertiary" />
-                  <h2 className="font-serif text-2xl font-semibold text-foreground">Job table</h2>
-                </div>
-                <div className="flex flex-wrap items-center gap-3">
-                  <span className="text-sm text-foreground-secondary">{selectionSummary}</span>
-                  <Button
-                    variant="outlined"
-                    color="inherit"
-                    startIcon={<VisibilityOffRoundedIcon />}
-                    disabled={!isAdmin || selectedIds.length === 0 || isProcessing}
-                    onClick={() => void handleHideSelected()}
-                  >
-                    {isProcessing ? "Working..." : "Hide selected"}
-                  </Button>
-                  <Button
-                    variant="outlined"
-                    color="error"
-                    startIcon={<DeleteOutlineRoundedIcon />}
-                    disabled={!isAdmin || selectedIds.length === 0 || isProcessing}
-                    onClick={() => void handleDeleteSelected()}
-                  >
-                    {isProcessing ? "Working..." : "Delete selected"}
-                  </Button>
-                </div>
-              </div>
-
-              <div className="grid gap-3 md:grid-cols-3 xl:grid-cols-7">
-                <TextField
-                  label="Keyword"
-                  size="small"
-                  value={draftFilters.keyword}
-                  onChange={(event) =>
-                    setDraftFilters((current) => ({ ...current, keyword: event.target.value }))
-                  }
-                />
-                <TextField
-                  label="Company"
-                  size="small"
-                  value={draftFilters.company}
-                  onChange={(event) =>
-                    setDraftFilters((current) => ({ ...current, company: event.target.value }))
-                  }
-                />
-                <TextField
-                  label="Postcode"
-                  size="small"
-                  value={draftFilters.postcode}
-                  onChange={(event) =>
-                    setDraftFilters((current) => ({ ...current, postcode: event.target.value }))
-                  }
-                />
-                <TextField
-                  label="Location"
-                  size="small"
-                  value={draftFilters.location}
-                  onChange={(event) =>
-                    setDraftFilters((current) => ({ ...current, location: event.target.value }))
-                  }
-                />
-                <TextField
-                  label="Source"
-                  size="small"
-                  value={draftFilters.sourceName}
-                  onChange={(event) =>
-                    setDraftFilters((current) => ({ ...current, sourceName: event.target.value }))
-                  }
-                />
-                <TextField
-                  label="Category"
-                  size="small"
-                  value={draftFilters.categoryTag}
-                  onChange={(event) =>
-                    setDraftFilters((current) => ({ ...current, categoryTag: event.target.value }))
-                  }
-                />
-                <TextField
-                  select
-                  label="Visibility"
-                  size="small"
-                  value={draftFilters.visibility}
-                  onChange={(event) =>
-                    setDraftFilters((current) => ({
-                      ...current,
-                      visibility: event.target.value as VisibilityFilter
-                    }))
-                  }
-                >
-                  <MenuItem value="visible">Visible</MenuItem>
-                  <MenuItem value="hidden">Hidden</MenuItem>
-                  <MenuItem value="all">All</MenuItem>
-                </TextField>
-              </div>
-
-              <div className="flex flex-wrap gap-3">
-                <Button
-                  variant="contained"
-                  onClick={() => {
-                    setPageIndex(0);
-                    setFilters(draftFilters);
-                  }}
-                  sx={{
-                    bgcolor: "accent.main",
-                    "&:hover": { bgcolor: "accent.dark" }
-                  }}
-                >
-                  Apply filters
-                </Button>
-                <Button
-                  variant="outlined"
-                  color="inherit"
-                  onClick={() => {
-                    setDraftFilters(emptyFilters);
-                    setPageIndex(0);
-                    setFilters(emptyFilters);
-                  }}
-                >
-                  Reset
-                </Button>
-              </div>
-            </div>
-          </div>
+          <JobsManagementToolbar
+            draftFilters={draftFilters}
+            isAdmin={isAdmin}
+            isProcessing={isProcessing}
+            selectionSummary={selectionSummary}
+            selectedCount={selectedIds.length}
+            onApplyFilters={() => {
+              setPageIndex(0);
+              setFilters(draftFilters);
+            }}
+            onDeleteSelected={() => void handleDeleteSelected()}
+            onFiltersChange={setDraftFilters}
+            onHideSelected={() => void handleHideSelected()}
+            onResetFilters={() => {
+              setDraftFilters(emptyFilters);
+              setPageIndex(0);
+              setFilters(emptyFilters);
+            }}
+          />
 
           {viewStatus === "loading" ? (
             <div className="p-6 text-sm text-foreground-secondary">Loading jobs from the API...</div>
@@ -352,109 +206,27 @@ export function JobsListView() {
           ) : null}
 
           {jobs.length > 0 ? (
-            <>
-              <TableContainer>
-                <Table size="small">
-                  <TableHead>
-                    <TableRow>
-                      <TableCell padding="checkbox">
-                        <Checkbox
-                          checked={allVisibleSelected}
-                          indeterminate={selectedVisibleCount > 0 && !allVisibleSelected}
-                          onChange={(event) =>
-                            setSelectedIds(event.target.checked ? jobs.map((job) => job.id) : [])
-                          }
-                          inputProps={{ "aria-label": "Select all jobs" }}
-                        />
-                      </TableCell>
-                      <TableCell>Title</TableCell>
-                      <TableCell>Company</TableCell>
-                      <TableCell>Location</TableCell>
-                      <TableCell>Source</TableCell>
-                      <TableCell>Status</TableCell>
-                      <TableCell>Posted</TableCell>
-                      <TableCell>Type</TableCell>
-                      <TableCell align="right">Salary</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {jobs.map((job) => {
-                      const isSelected = selectedIds.includes(job.id);
-
-                      return (
-                        <TableRow
-                          key={job.id}
-                          hover
-                          selected={isSelected}
-                          onClick={() => void navigate(`/admin/manage-jobs/${job.id}`)}
-                          sx={{ cursor: "pointer" }}
-                        >
-                          <TableCell
-                            padding="checkbox"
-                            onClick={(event) => {
-                              event.stopPropagation();
-                            }}
-                          >
-                            <Checkbox
-                              checked={isSelected}
-                              onChange={(event) => {
-                                setSelectedIds((current) =>
-                                  event.target.checked
-                                    ? [...current, job.id]
-                                    : current.filter((id) => id !== job.id)
-                                );
-                              }}
-                              inputProps={{ "aria-label": `Select job ${job.id}` }}
-                            />
-                          </TableCell>
-                          <TableCell>
-                            <div className="max-w-[280px]">
-                              <div className="font-medium text-foreground">{job.title}</div>
-                              <div className="mt-1 truncate text-xs text-foreground-tertiary">
-                                #{job.id} · {job.sourceJobId}
-                              </div>
-                            </div>
-                          </TableCell>
-                          <TableCell>{job.companyDisplayName ?? job.company}</TableCell>
-                          <TableCell>
-                            <div className="max-w-[180px] truncate">
-                              {job.locationDisplayName ?? job.locationName}
-                            </div>
-                          </TableCell>
-                          <TableCell>{job.sourceName}</TableCell>
-                          <TableCell>
-                            <div className="flex flex-wrap gap-1">
-                              {job.isHidden ? (
-                                <Chip size="small" label="Hidden" color="warning" variant="outlined" />
-                              ) : (
-                                <Chip size="small" label="Visible" color="success" variant="outlined" />
-                              )}
-                              {job.isRemote ? <Chip size="small" label="Remote" variant="outlined" /> : null}
-                            </div>
-                          </TableCell>
-                          <TableCell>{formatDate(job.postedAtUtc)}</TableCell>
-                          <TableCell>{formatJobType(job)}</TableCell>
-                          <TableCell align="right">{formatSalary(job)}</TableCell>
-                        </TableRow>
-                      );
-                    })}
-                  </TableBody>
-                </Table>
-              </TableContainer>
-
-              <TablePagination
-                component="div"
-                count={totalCount}
-                page={pageIndex}
-                onPageChange={(_, nextPage) => setPageIndex(nextPage)}
-                rowsPerPage={pageSize}
-                onRowsPerPageChange={(event) => {
-                  setPageSize(Number(event.target.value));
-                  setPageIndex(0);
-                }}
-                rowsPerPageOptions={[20, 50, 100]}
-              />
-            </>
+            <JobsManagementTable
+              jobs={jobs}
+              pageIndex={pageIndex}
+              pageSize={pageSize}
+              selectedIds={selectedIds}
+              totalCount={totalCount}
+              onOpenJob={(jobId) => void navigate(`/admin/manage-jobs/${jobId}`)}
+              onPageChange={setPageIndex}
+              onPageSizeChange={(nextPageSize) => {
+                setPageSize(nextPageSize);
+                setPageIndex(0);
+              }}
+              onSelectAll={(checked) => {
+                setSelectedIds(checked ? jobs.map((job) => job.id) : []);
+              }}
+              onSelectJob={(jobId, checked) => {
+                setSelectedIds((current) =>
+                  checked ? [...current, jobId] : current.filter((id) => id !== jobId)
+                );
+              }}
+            />
           ) : null}
         </SectionCard>
       </div>
@@ -473,61 +245,6 @@ function mapVisibilityToHiddenFlag(value: VisibilityFilter): boolean | undefined
 function normalizeText(value: string): string | undefined {
   const trimmed = value.trim();
   return trimmed ? trimmed : undefined;
-}
-
-function formatDate(value: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return "Unknown";
-  }
-
-  return new Intl.DateTimeFormat("en-GB", {
-    day: "numeric",
-    month: "short",
-    year: "numeric"
-  }).format(date);
-}
-
-function formatSalary(job: JobDetailsResponseDto): string {
-  if (job.salaryMin === null && job.salaryMax === null) {
-    return "N/A";
-  }
-
-  const formatter = new Intl.NumberFormat("en-GB", {
-    style: "currency",
-    currency: job.salaryCurrency ?? "GBP",
-    maximumFractionDigits: 0
-  });
-
-  if (job.salaryMin !== null && job.salaryMax !== null) {
-    return `${formatter.format(job.salaryMin)} - ${formatter.format(job.salaryMax)}`;
-  }
-
-  return formatter.format(job.salaryMin ?? job.salaryMax ?? 0);
-}
-
-function formatJobType(job: JobDetailsResponseDto): string {
-  if (job.contractType) {
-    return job.contractType.replaceAll("_", " ");
-  }
-
-  if (job.isPermanent) {
-    return "permanent";
-  }
-
-  if (job.isContract) {
-    return "contract";
-  }
-
-  if (job.isFullTime) {
-    return "full time";
-  }
-
-  if (job.isPartTime) {
-    return "part time";
-  }
-
-  return "unspecified";
 }
 
 function buildHideSummary(hiddenCount: number, missingCount: number): string {

--- a/apps/web/src/features/jobs/views/JobsListView.tsx
+++ b/apps/web/src/features/jobs/views/JobsListView.tsx
@@ -49,7 +49,7 @@ const emptyFilters: JobsListFilters = {
   visibility: "visible"
 };
 
-const pageSize = 20;
+const defaultPageSize = 20;
 
 export function JobsListView() {
   const navigate = useNavigate();
@@ -58,15 +58,20 @@ export function JobsListView() {
   const [draftFilters, setDraftFilters] = useState<JobsListFilters>(emptyFilters);
   const [filters, setFilters] = useState<JobsListFilters>(emptyFilters);
   const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = useState(defaultPageSize);
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
   const [actionMessage, setActionMessage] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
 
-  const loadJobs = useCallback(async (nextPageIndex: number, nextFilters: JobsListFilters) => {
+  const loadJobs = useCallback(async (
+    nextPageIndex: number,
+    nextPageSize: number,
+    nextFilters: JobsListFilters
+  ) => {
     return getJobsPage({
       pageIndex: nextPageIndex,
-      pageSize,
+      pageSize: nextPageSize,
       keyword: normalizeText(nextFilters.keyword),
       company: normalizeText(nextFilters.company),
       postcode: normalizeText(nextFilters.postcode),
@@ -80,8 +85,8 @@ export function JobsListView() {
   const { status, data, errorMessage, execute } = useAsyncTask(loadJobs);
 
   useEffect(() => {
-    void execute(pageIndex, filters);
-  }, [execute, filters, pageIndex]);
+    void execute(pageIndex, pageSize, filters);
+  }, [execute, filters, pageIndex, pageSize]);
 
   useEffect(() => {
     const visibleIds = new Set((data?.items ?? []).map((job) => job.id));
@@ -115,7 +120,7 @@ export function JobsListView() {
       const result = await hideJobs(selectedIds);
       setActionMessage(buildHideSummary(result.hiddenCount, result.missingIds.length));
       setSelectedIds([]);
-      await execute(pageIndex, filters);
+      await execute(pageIndex, pageSize, filters);
     } catch (error) {
       setActionError(error instanceof Error ? error.message : "Unable to hide the selected jobs.");
     } finally {
@@ -140,7 +145,7 @@ export function JobsListView() {
       const result = await deleteJobs(selectedIds);
       setActionMessage(buildDeleteSummary(result));
       setSelectedIds([]);
-      await execute(pageIndex, filters);
+      await execute(pageIndex, pageSize, filters);
     } catch (error) {
       setActionError(error instanceof Error ? error.message : "Unable to delete the selected jobs.");
     } finally {
@@ -443,7 +448,11 @@ export function JobsListView() {
                 page={pageIndex}
                 onPageChange={(_, nextPage) => setPageIndex(nextPage)}
                 rowsPerPage={pageSize}
-                rowsPerPageOptions={[pageSize]}
+                onRowsPerPageChange={(event) => {
+                  setPageSize(Number(event.target.value));
+                  setPageIndex(0);
+                }}
+                rowsPerPageOptions={[20, 50, 100]}
               />
             </>
           ) : null}

--- a/apps/web/src/features/jobs/views/ManageJobView.test.tsx
+++ b/apps/web/src/features/jobs/views/ManageJobView.test.tsx
@@ -112,5 +112,5 @@ describe("ManageJobView", () => {
     expect(hideJob).toHaveBeenCalledWith(42);
 
     confirmSpy.mockRestore();
-  });
+  }, 10000);
 });

--- a/apps/web/src/features/jobs/views/ManageJobView.test.tsx
+++ b/apps/web/src/features/jobs/views/ManageJobView.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { theme } from "@/app/theme";
+import { deleteJob, getJobById, hideJob } from "@/api/jobs/jobs.api";
+import { ManageJobView } from "@/features/jobs/views/ManageJobView";
+import { useSessionStore } from "@/store/session.store";
+
+vi.mock("@/api/jobs/jobs.api", () => ({
+  createJob: vi.fn(),
+  deleteJob: vi.fn(),
+  getJobById: vi.fn(),
+  hideJob: vi.fn(),
+  updateJob: vi.fn()
+}));
+
+describe("ManageJobView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSessionStore.setState({
+      user: {
+        userAccount: "admin",
+        displayName: "Admin",
+        role: "admin",
+        email: "admin@example.com"
+      },
+      isAuthenticated: true
+    });
+  });
+
+  it("surfaces the delete conflict and lets the user hide the job", async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    vi.mocked(getJobById).mockResolvedValueOnce({
+      id: 42,
+      jobRefreshRunId: null,
+      sourceName: "Adzuna",
+      sourceJobId: "adz-42",
+      sourceAdReference: null,
+      title: "Senior Frontend Engineer",
+      description: "Build the web application.",
+      summary: "Build the web application.",
+      url: "https://example.com/jobs/42",
+      company: "Firefly",
+      companyDisplayName: "Firefly",
+      companyCanonicalName: "firefly",
+      postcode: "EC2A 4NE",
+      locationName: "London",
+      locationDisplayName: "London",
+      locationAreaJson: "[\"London\"]",
+      latitude: null,
+      longitude: null,
+      categoryTag: "it-jobs",
+      categoryLabel: "IT jobs",
+      salaryMin: 75000,
+      salaryMax: 95000,
+      salaryCurrency: "GBP",
+      salaryIsPredicted: false,
+      contractTime: "full_time",
+      contractType: "permanent",
+      isFullTime: true,
+      isPartTime: false,
+      isPermanent: true,
+      isContract: false,
+      isRemote: true,
+      postedAtUtc: "2025-04-03T10:00:00Z",
+      importedAtUtc: "2025-04-03T12:00:00Z",
+      lastSeenAtUtc: "2025-04-03T12:00:00Z",
+      isHidden: false,
+      rawPayloadJson: "{}"
+    });
+    vi.mocked(deleteJob).mockRejectedValueOnce(
+      new Error("Job 42 must be hidden before it can be deleted.")
+    );
+    vi.mocked(hideJob).mockResolvedValueOnce({
+      hiddenCount: 1,
+      hiddenIds: [42],
+      missingIds: []
+    });
+
+    render(
+      <ThemeProvider theme={theme}>
+        <MemoryRouter>
+          <ManageJobView jobId="42" />
+        </MemoryRouter>
+      </ThemeProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Senior Frontend Engineer")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete job" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Job 42 must be hidden before it can be deleted.")
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Hide job" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Job hidden successfully.")).toBeInTheDocument();
+    });
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(deleteJob).toHaveBeenCalledWith(42);
+    expect(hideJob).toHaveBeenCalledWith(42);
+
+    confirmSpy.mockRestore();
+  });
+});

--- a/apps/web/src/features/jobs/views/ManageJobView.tsx
+++ b/apps/web/src/features/jobs/views/ManageJobView.tsx
@@ -1,0 +1,821 @@
+import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
+import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
+import SaveRoundedIcon from "@mui/icons-material/SaveRounded";
+import VisibilityOffRoundedIcon from "@mui/icons-material/VisibilityOffRounded";
+import {
+  Alert,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  TextField
+} from "@mui/material";
+import { useEffect, useState } from "react";
+import type { Dispatch, FormEvent, ReactNode, SetStateAction } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { AppHeader } from "@/components/AppHeader";
+import { SectionCard } from "@/components/SectionCard";
+import {
+  createJob,
+  deleteJob,
+  getJobById,
+  hideJob,
+  updateJob
+} from "@/api/jobs/jobs.api";
+import type {
+  CreateJobRequestDto,
+  JobDetailsResponseDto
+} from "@/api/jobs/jobs.types";
+import { createAsyncState, type AsyncState } from "@/lib/async/async-state";
+import { useSessionStore } from "@/store/session.store";
+
+type ManageJobViewProps = {
+  jobId?: string;
+};
+
+export function ManageJobView({ jobId }: ManageJobViewProps) {
+  const navigate = useNavigate();
+  const user = useSessionStore((state) => state.user);
+  const isAdmin = user?.role === "admin";
+  const numericJobId = jobId ? Number(jobId) : null;
+  const isCreateMode = numericJobId === null;
+  const [jobState, setJobState] = useState<AsyncState<JobDetailsResponseDto, "idle" | "loading" | "success" | "error">>(
+    createAsyncState<JobDetailsResponseDto, "idle" | "loading" | "success" | "error">(
+      isCreateMode ? "success" : "idle",
+      null
+    )
+  );
+  const [formValues, setFormValues] = useState<CreateJobRequestDto>(createDefaultJobFormValues());
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isHiding, setIsHiding] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    if (isCreateMode) {
+      return;
+    }
+
+    if (numericJobId === null || Number.isNaN(numericJobId)) {
+      setJobState(
+        createAsyncState<JobDetailsResponseDto, "idle" | "loading" | "success" | "error">(
+          "error",
+          null,
+          "That job id is invalid."
+        )
+      );
+      return;
+    }
+
+    let isMounted = true;
+    const nextJobId = numericJobId;
+
+    async function loadJob() {
+      setJobState(
+        createAsyncState<JobDetailsResponseDto, "idle" | "loading" | "success" | "error">(
+          "loading",
+          null
+        )
+      );
+
+      try {
+        const response = await getJobById(nextJobId);
+        if (!isMounted) {
+          return;
+        }
+
+        setJobState(
+          createAsyncState<JobDetailsResponseDto, "idle" | "loading" | "success" | "error">(
+            "success",
+            response
+          )
+        );
+        setFormValues(mapJobToFormValues(response));
+      } catch (error) {
+        if (!isMounted) {
+          return;
+        }
+
+        setJobState(
+          createAsyncState<JobDetailsResponseDto, "idle" | "loading" | "success" | "error">(
+            "error",
+            null,
+            error instanceof Error ? error.message : "Unable to load this job."
+          )
+        );
+      }
+    }
+
+    void loadJob();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [isCreateMode, numericJobId]);
+
+  const pageTitle = isCreateMode ? "Create job resource" : `Manage job #${numericJobId}`;
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void submitForm();
+  }
+
+  async function submitForm() {
+    if (!isAdmin) {
+      setErrorMessage("Only admin sessions can save job resources.");
+      return;
+    }
+
+    setIsSaving(true);
+    setSaveMessage(null);
+    setErrorMessage(null);
+
+    try {
+      const payload = normalizeFormValues(formValues);
+
+      if (isCreateMode) {
+        const created = await createJob(payload);
+        setSaveMessage("Job created successfully.");
+        void navigate(`/admin/manage-jobs/${created.id}`, { replace: true });
+        return;
+      }
+
+      if (numericJobId === null) {
+        throw new Error("This job id is missing.");
+      }
+
+      const updated = await updateJob(numericJobId, payload);
+      setFormValues(mapJobToFormValues(updated));
+      setJobState(
+        createAsyncState<JobDetailsResponseDto, "idle" | "loading" | "success" | "error">(
+          "success",
+          updated
+        )
+      );
+      setSaveMessage("Job updated successfully.");
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Unable to save this job.");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleHide() {
+    if (!isAdmin || numericJobId === null) {
+      setErrorMessage("Only admin sessions can hide job resources.");
+      return;
+    }
+
+    setIsHiding(true);
+    setSaveMessage(null);
+    setErrorMessage(null);
+
+    try {
+      await hideJob(numericJobId);
+      setFormValues((current) => ({ ...current, isHidden: true }));
+      setSaveMessage("Job hidden successfully.");
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Unable to hide this job.");
+    } finally {
+      setIsHiding(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!isAdmin || numericJobId === null) {
+      setErrorMessage("Only admin sessions can delete job resources.");
+      return;
+    }
+
+    if (!window.confirm("Delete this job resource? The backend will reject this if the job is not hidden.")) {
+      return;
+    }
+
+    setIsDeleting(true);
+    setSaveMessage(null);
+    setErrorMessage(null);
+
+    try {
+      await deleteJob(numericJobId);
+      void navigate("/admin/manage-jobs", { replace: true });
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Unable to delete this job."
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  if (jobState.status === "loading") {
+    return (
+      <div className="min-h-screen bg-background">
+        <AppHeader variant="authenticated" />
+        <div className="mx-auto max-w-5xl px-5 py-8 sm:px-8">
+          <SectionCard className="p-6">
+            <p className="text-sm text-foreground-secondary">Loading job resource...</p>
+          </SectionCard>
+        </div>
+      </div>
+    );
+  }
+
+  if (jobState.status === "error") {
+    return (
+      <div className="min-h-screen bg-background">
+        <AppHeader variant="authenticated" />
+        <div className="mx-auto max-w-5xl px-5 py-8 sm:px-8">
+          <Alert severity="error">{jobState.errorMessage ?? "Unable to load this job."}</Alert>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <AppHeader variant="authenticated" />
+
+      <div className="mx-auto max-w-5xl px-5 py-8 sm:px-8">
+        <Link
+          to="/admin/manage-jobs"
+          className="inline-flex items-center gap-2 text-sm text-foreground-secondary transition-colors hover:text-accent-primary"
+        >
+          <ArrowBackRoundedIcon sx={{ fontSize: 18 }} />
+          Back to jobs
+        </Link>
+
+        <div className="mt-6 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="font-mono text-xs tracking-[0.2em] text-foreground-tertiary">
+              BACKEND-ALIGNED JOB CONTRACT
+            </p>
+            <h1 className="mt-2 font-serif text-4xl font-semibold text-foreground">{pageTitle}</h1>
+            <p className="mt-3 max-w-3xl text-sm text-foreground-secondary">
+              This editor mirrors the backend jobs contract directly, including hide and delete
+              behavior enforced by the API.
+            </p>
+          </div>
+          {!isCreateMode ? (
+            <div className="rounded-lg border border-border bg-background-elevated px-4 py-3 text-sm text-foreground-secondary">
+              Resource ID <span className="font-medium text-foreground">{numericJobId}</span>
+            </div>
+          ) : null}
+        </div>
+
+        {!isAdmin ? (
+          <Alert severity="info" sx={{ mt: 4 }}>
+            You can inspect the job resource, but save, hide, and delete actions require an admin
+            role from the backend API.
+          </Alert>
+        ) : null}
+
+        {saveMessage ? <Alert severity="success" sx={{ mt: 4 }}>{saveMessage}</Alert> : null}
+        {errorMessage ? <Alert severity="error" sx={{ mt: 4 }}>{errorMessage}</Alert> : null}
+
+        <form onSubmit={handleSubmit} className="mt-6 space-y-6">
+          <JobFieldSection title="Core">
+            <TextField
+              label="Title"
+              value={formValues.title}
+              onChange={(event) => setStringValue(setFormValues, "title", event.target.value)}
+              fullWidth
+              required
+            />
+            <TextField
+              label="Company"
+              value={formValues.company}
+              onChange={(event) => setStringValue(setFormValues, "company", event.target.value)}
+              fullWidth
+              required
+            />
+            <TextField
+              label="Job URL"
+              value={formValues.url}
+              onChange={(event) => setStringValue(setFormValues, "url", event.target.value)}
+              fullWidth
+              required
+            />
+            <TextField
+              label="Summary"
+              value={formValues.summary}
+              onChange={(event) => setStringValue(setFormValues, "summary", event.target.value)}
+              fullWidth
+              required
+              multiline
+              minRows={3}
+            />
+            <TextField
+              label="Description"
+              value={formValues.description}
+              onChange={(event) => setStringValue(setFormValues, "description", event.target.value)}
+              fullWidth
+              required
+              multiline
+              minRows={5}
+            />
+          </JobFieldSection>
+
+          <JobFieldSection title="Source">
+            <TextField
+              label="Source name"
+              value={formValues.sourceName}
+              onChange={(event) => setStringValue(setFormValues, "sourceName", event.target.value)}
+              fullWidth
+              required
+            />
+            <TextField
+              label="Source job ID"
+              value={formValues.sourceJobId}
+              onChange={(event) => setStringValue(setFormValues, "sourceJobId", event.target.value)}
+              fullWidth
+              required
+            />
+            <TextField
+              label="Source ad reference"
+              value={formValues.sourceAdReference ?? ""}
+              onChange={(event) =>
+                setNullableStringValue(setFormValues, "sourceAdReference", event.target.value)
+              }
+              fullWidth
+            />
+            <TextField
+              label="Job refresh run ID"
+              value={formValues.jobRefreshRunId ?? ""}
+              onChange={(event) =>
+                setNullableNumberValue(setFormValues, "jobRefreshRunId", event.target.value)
+              }
+              fullWidth
+            />
+            <TextField
+              label="Raw payload JSON"
+              value={formValues.rawPayloadJson}
+              onChange={(event) =>
+                setStringValue(setFormValues, "rawPayloadJson", event.target.value)
+              }
+              fullWidth
+              required
+              multiline
+              minRows={4}
+            />
+          </JobFieldSection>
+
+          <JobFieldSection title="Location">
+            <TextField
+              label="Postcode"
+              value={formValues.postcode}
+              onChange={(event) => setStringValue(setFormValues, "postcode", event.target.value)}
+              fullWidth
+              required
+            />
+            <TextField
+              label="Location name"
+              value={formValues.locationName}
+              onChange={(event) =>
+                setStringValue(setFormValues, "locationName", event.target.value)
+              }
+              fullWidth
+              required
+            />
+            <TextField
+              label="Location display name"
+              value={formValues.locationDisplayName ?? ""}
+              onChange={(event) =>
+                setNullableStringValue(setFormValues, "locationDisplayName", event.target.value)
+              }
+              fullWidth
+            />
+            <TextField
+              label="Location area JSON"
+              value={formValues.locationAreaJson ?? ""}
+              onChange={(event) =>
+                setNullableStringValue(setFormValues, "locationAreaJson", event.target.value)
+              }
+              fullWidth
+            />
+            <TextField
+              label="Latitude"
+              value={formValues.latitude ?? ""}
+              onChange={(event) =>
+                setNullableNumberValue(setFormValues, "latitude", event.target.value)
+              }
+              fullWidth
+            />
+            <TextField
+              label="Longitude"
+              value={formValues.longitude ?? ""}
+              onChange={(event) =>
+                setNullableNumberValue(setFormValues, "longitude", event.target.value)
+              }
+              fullWidth
+            />
+          </JobFieldSection>
+
+          <JobFieldSection title="Classification and salary">
+            <TextField
+              label="Category tag"
+              value={formValues.categoryTag ?? ""}
+              onChange={(event) =>
+                setNullableStringValue(setFormValues, "categoryTag", event.target.value)
+              }
+              fullWidth
+            />
+            <TextField
+              label="Category label"
+              value={formValues.categoryLabel ?? ""}
+              onChange={(event) =>
+                setNullableStringValue(setFormValues, "categoryLabel", event.target.value)
+              }
+              fullWidth
+            />
+            <TextField
+              label="Salary min"
+              value={formValues.salaryMin ?? ""}
+              onChange={(event) =>
+                setNullableNumberValue(setFormValues, "salaryMin", event.target.value)
+              }
+              fullWidth
+            />
+            <TextField
+              label="Salary max"
+              value={formValues.salaryMax ?? ""}
+              onChange={(event) =>
+                setNullableNumberValue(setFormValues, "salaryMax", event.target.value)
+              }
+              fullWidth
+            />
+            <TextField
+              label="Salary currency"
+              value={formValues.salaryCurrency ?? ""}
+              onChange={(event) =>
+                setNullableStringValue(setFormValues, "salaryCurrency", event.target.value)
+              }
+              fullWidth
+            />
+            <TextField
+              label="Contract time"
+              value={formValues.contractTime ?? ""}
+              onChange={(event) =>
+                setNullableStringValue(setFormValues, "contractTime", event.target.value)
+              }
+              fullWidth
+            />
+            <TextField
+              label="Contract type"
+              value={formValues.contractType ?? ""}
+              onChange={(event) =>
+                setNullableStringValue(setFormValues, "contractType", event.target.value)
+              }
+              fullWidth
+            />
+          </JobFieldSection>
+
+          <JobFieldSection title="Flags and timestamps">
+            <div className="grid gap-2 md:grid-cols-3">
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={formValues.isFullTime}
+                    onChange={(event) =>
+                      setBooleanValue(setFormValues, "isFullTime", event.target.checked)
+                    }
+                  />
+                }
+                label="Full time"
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={formValues.isPartTime}
+                    onChange={(event) =>
+                      setBooleanValue(setFormValues, "isPartTime", event.target.checked)
+                    }
+                  />
+                }
+                label="Part time"
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={formValues.isPermanent}
+                    onChange={(event) =>
+                      setBooleanValue(setFormValues, "isPermanent", event.target.checked)
+                    }
+                  />
+                }
+                label="Permanent"
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={formValues.isContract}
+                    onChange={(event) =>
+                      setBooleanValue(setFormValues, "isContract", event.target.checked)
+                    }
+                  />
+                }
+                label="Contract"
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={formValues.isRemote}
+                    onChange={(event) =>
+                      setBooleanValue(setFormValues, "isRemote", event.target.checked)
+                    }
+                  />
+                }
+                label="Remote"
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={formValues.isHidden}
+                    onChange={(event) =>
+                      setBooleanValue(setFormValues, "isHidden", event.target.checked)
+                    }
+                  />
+                }
+                label="Hidden"
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={formValues.salaryIsPredicted ?? false}
+                    onChange={(event) =>
+                      setNullableBooleanValue(
+                        setFormValues,
+                        "salaryIsPredicted",
+                        event.target.checked
+                      )
+                    }
+                  />
+                }
+                label="Salary predicted"
+              />
+            </div>
+            <TextField
+              label="Posted at UTC"
+              value={formValues.postedAtUtc}
+              onChange={(event) =>
+                setStringValue(setFormValues, "postedAtUtc", event.target.value)
+              }
+              fullWidth
+              required
+            />
+            <TextField
+              label="Imported at UTC"
+              value={formValues.importedAtUtc}
+              onChange={(event) =>
+                setStringValue(setFormValues, "importedAtUtc", event.target.value)
+              }
+              fullWidth
+              required
+            />
+            <TextField
+              label="Last seen at UTC"
+              value={formValues.lastSeenAtUtc}
+              onChange={(event) =>
+                setStringValue(setFormValues, "lastSeenAtUtc", event.target.value)
+              }
+              fullWidth
+              required
+            />
+          </JobFieldSection>
+
+          <SectionCard className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between">
+            <div className="text-sm text-foreground-secondary">
+              {isCreateMode
+                ? "Create a new job resource in the backend table."
+                : "Save changes, hide the job, or delete it after it has been hidden."}
+            </div>
+            <div className="flex flex-wrap gap-3">
+              {!isCreateMode ? (
+                <Button
+                  type="button"
+                  variant="outlined"
+                  color="inherit"
+                  startIcon={<VisibilityOffRoundedIcon />}
+                  disabled={!isAdmin || isHiding || isSaving || isDeleting}
+                  onClick={() => void handleHide()}
+                >
+                  {isHiding ? "Hiding..." : "Hide job"}
+                </Button>
+              ) : null}
+              {!isCreateMode ? (
+                <Button
+                  type="button"
+                  color="error"
+                  variant="outlined"
+                  startIcon={<DeleteOutlineRoundedIcon />}
+                  disabled={!isAdmin || isDeleting || isSaving || isHiding}
+                  onClick={() => void handleDelete()}
+                >
+                  {isDeleting ? "Deleting..." : "Delete job"}
+                </Button>
+              ) : null}
+              <Button
+                type="submit"
+                variant="contained"
+                startIcon={<SaveRoundedIcon />}
+                disabled={!isAdmin || isSaving || isHiding || isDeleting}
+                sx={{
+                  bgcolor: "accent.main",
+                  "&:hover": { bgcolor: "accent.dark" }
+                }}
+              >
+                {isSaving ? "Saving..." : isCreateMode ? "Create job" : "Save changes"}
+              </Button>
+            </div>
+          </SectionCard>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function JobFieldSection({
+  children,
+  title
+}: {
+  children: ReactNode;
+  title: string;
+}) {
+  return (
+    <SectionCard className="p-6">
+      <h2 className="font-serif text-2xl font-semibold text-foreground">{title}</h2>
+      <div className="mt-5 grid gap-4 md:grid-cols-2">{children}</div>
+    </SectionCard>
+  );
+}
+
+function createDefaultJobFormValues(): CreateJobRequestDto {
+  const now = new Date().toISOString();
+
+  return {
+    jobRefreshRunId: null,
+    sourceName: "",
+    sourceJobId: "",
+    sourceAdReference: null,
+    title: "",
+    description: "",
+    summary: "",
+    url: "",
+    company: "",
+    companyDisplayName: null,
+    companyCanonicalName: null,
+    postcode: "",
+    locationName: "",
+    locationDisplayName: null,
+    locationAreaJson: null,
+    latitude: null,
+    longitude: null,
+    categoryTag: null,
+    categoryLabel: null,
+    salaryMin: null,
+    salaryMax: null,
+    salaryCurrency: "GBP",
+    salaryIsPredicted: false,
+    contractTime: null,
+    contractType: null,
+    isFullTime: false,
+    isPartTime: false,
+    isPermanent: false,
+    isContract: false,
+    isRemote: false,
+    postedAtUtc: now,
+    importedAtUtc: now,
+    lastSeenAtUtc: now,
+    isHidden: false,
+    rawPayloadJson: "{}"
+  };
+}
+
+function mapJobToFormValues(job: JobDetailsResponseDto): CreateJobRequestDto {
+  return {
+    jobRefreshRunId: job.jobRefreshRunId,
+    sourceName: job.sourceName,
+    sourceJobId: job.sourceJobId,
+    sourceAdReference: job.sourceAdReference,
+    title: job.title,
+    description: job.description,
+    summary: job.summary,
+    url: job.url,
+    company: job.company,
+    companyDisplayName: job.companyDisplayName,
+    companyCanonicalName: job.companyCanonicalName,
+    postcode: job.postcode,
+    locationName: job.locationName,
+    locationDisplayName: job.locationDisplayName,
+    locationAreaJson: job.locationAreaJson,
+    latitude: job.latitude,
+    longitude: job.longitude,
+    categoryTag: job.categoryTag,
+    categoryLabel: job.categoryLabel,
+    salaryMin: job.salaryMin,
+    salaryMax: job.salaryMax,
+    salaryCurrency: job.salaryCurrency,
+    salaryIsPredicted: job.salaryIsPredicted,
+    contractTime: job.contractTime,
+    contractType: job.contractType,
+    isFullTime: job.isFullTime,
+    isPartTime: job.isPartTime,
+    isPermanent: job.isPermanent,
+    isContract: job.isContract,
+    isRemote: job.isRemote,
+    postedAtUtc: job.postedAtUtc,
+    importedAtUtc: job.importedAtUtc,
+    lastSeenAtUtc: job.lastSeenAtUtc,
+    isHidden: job.isHidden,
+    rawPayloadJson: job.rawPayloadJson
+  };
+}
+
+function normalizeFormValues(values: CreateJobRequestDto): CreateJobRequestDto {
+  return {
+    ...values,
+    sourceName: values.sourceName.trim(),
+    sourceJobId: values.sourceJobId.trim(),
+    title: values.title.trim(),
+    description: values.description.trim(),
+    summary: values.summary.trim(),
+    url: values.url.trim(),
+    company: values.company.trim(),
+    postcode: values.postcode.trim(),
+    locationName: values.locationName.trim(),
+    rawPayloadJson: values.rawPayloadJson.trim() || "{}",
+    sourceAdReference: normalizeNullableString(values.sourceAdReference),
+    companyDisplayName: normalizeNullableString(values.companyDisplayName),
+    companyCanonicalName: normalizeNullableString(values.companyCanonicalName),
+    locationDisplayName: normalizeNullableString(values.locationDisplayName),
+    locationAreaJson: normalizeNullableString(values.locationAreaJson),
+    categoryTag: normalizeNullableString(values.categoryTag),
+    categoryLabel: normalizeNullableString(values.categoryLabel),
+    salaryCurrency: normalizeNullableString(values.salaryCurrency),
+    contractTime: normalizeNullableString(values.contractTime),
+    contractType: normalizeNullableString(values.contractType)
+  };
+}
+
+function normalizeNullableString(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function setStringValue<TKey extends keyof CreateJobRequestDto>(
+  setFormValues: Dispatch<SetStateAction<CreateJobRequestDto>>,
+  key: TKey,
+  value: CreateJobRequestDto[TKey]
+) {
+  setFormValues((current) => ({
+    ...current,
+    [key]: value
+  }));
+}
+
+function setNullableStringValue<TKey extends keyof CreateJobRequestDto>(
+  setFormValues: Dispatch<SetStateAction<CreateJobRequestDto>>,
+  key: TKey,
+  value: string
+) {
+  setFormValues((current) => ({
+    ...current,
+    [key]: value === "" ? null : value
+  }));
+}
+
+function setNullableNumberValue<TKey extends keyof CreateJobRequestDto>(
+  setFormValues: Dispatch<SetStateAction<CreateJobRequestDto>>,
+  key: TKey,
+  value: string
+) {
+  setFormValues((current) => ({
+    ...current,
+    [key]: value === "" ? null : Number(value)
+  }));
+}
+
+function setBooleanValue<TKey extends keyof CreateJobRequestDto>(
+  setFormValues: Dispatch<SetStateAction<CreateJobRequestDto>>,
+  key: TKey,
+  value: boolean
+) {
+  setFormValues((current) => ({
+    ...current,
+    [key]: value
+  }));
+}
+
+function setNullableBooleanValue<TKey extends keyof CreateJobRequestDto>(
+  setFormValues: Dispatch<SetStateAction<CreateJobRequestDto>>,
+  key: TKey,
+  value: boolean
+) {
+  setFormValues((current) => ({
+    ...current,
+    [key]: value
+  }));
+}

--- a/apps/web/src/features/jobs/views/ManageJobView.tsx
+++ b/apps/web/src/features/jobs/views/ManageJobView.tsx
@@ -1,17 +1,7 @@
-import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
-import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
-import SaveRoundedIcon from "@mui/icons-material/SaveRounded";
-import VisibilityOffRoundedIcon from "@mui/icons-material/VisibilityOffRounded";
-import {
-  Alert,
-  Button,
-  Checkbox,
-  FormControlLabel,
-  TextField
-} from "@mui/material";
+import { Alert } from "@mui/material";
 import { useEffect, useState } from "react";
-import type { Dispatch, FormEvent, ReactNode, SetStateAction } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import type { FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
 import { AppHeader } from "@/components/AppHeader";
 import { SectionCard } from "@/components/SectionCard";
 import {
@@ -25,6 +15,9 @@ import type {
   CreateJobRequestDto,
   JobDetailsResponseDto
 } from "@/api/jobs/jobs.types";
+import { JobEditorAlerts } from "@/features/jobs/components/JobEditorAlerts";
+import { JobEditorForm } from "@/features/jobs/components/JobEditorForm";
+import { JobEditorHeader } from "@/features/jobs/components/JobEditorHeader";
 import { createAsyncState, type AsyncState } from "@/lib/async/async-state";
 import { useSessionStore } from "@/store/session.store";
 
@@ -236,415 +229,30 @@ export function ManageJobView({ jobId }: ManageJobViewProps) {
       <AppHeader variant="authenticated" />
 
       <div className="mx-auto max-w-5xl px-5 py-8 sm:px-8">
-        <Link
-          to="/admin/manage-jobs"
-          className="inline-flex items-center gap-2 text-sm text-foreground-secondary transition-colors hover:text-accent-primary"
-        >
-          <ArrowBackRoundedIcon sx={{ fontSize: 18 }} />
-          Back to jobs
-        </Link>
-
-        <div className="mt-6 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-          <div>
-            <p className="font-mono text-xs tracking-[0.2em] text-foreground-tertiary">
-              BACKEND-ALIGNED JOB CONTRACT
-            </p>
-            <h1 className="mt-2 font-serif text-4xl font-semibold text-foreground">{pageTitle}</h1>
-            <p className="mt-3 max-w-3xl text-sm text-foreground-secondary">
-              This editor mirrors the backend jobs contract directly, including hide and delete
-              behavior enforced by the API.
-            </p>
-          </div>
-          {!isCreateMode ? (
-            <div className="rounded-lg border border-border bg-background-elevated px-4 py-3 text-sm text-foreground-secondary">
-              Resource ID <span className="font-medium text-foreground">{numericJobId}</span>
-            </div>
-          ) : null}
-        </div>
-
-        {!isAdmin ? (
-          <Alert severity="info" sx={{ mt: 4 }}>
-            You can inspect the job resource, but save, hide, and delete actions require an admin
-            role from the backend API.
-          </Alert>
-        ) : null}
-
-        {saveMessage ? <Alert severity="success" sx={{ mt: 4 }}>{saveMessage}</Alert> : null}
-        {errorMessage ? <Alert severity="error" sx={{ mt: 4 }}>{errorMessage}</Alert> : null}
-
-        <form onSubmit={handleSubmit} className="mt-6 space-y-6">
-          <JobFieldSection title="Core">
-            <TextField
-              label="Title"
-              value={formValues.title}
-              onChange={(event) => setStringValue(setFormValues, "title", event.target.value)}
-              fullWidth
-              required
-            />
-            <TextField
-              label="Company"
-              value={formValues.company}
-              onChange={(event) => setStringValue(setFormValues, "company", event.target.value)}
-              fullWidth
-              required
-            />
-            <TextField
-              label="Job URL"
-              value={formValues.url}
-              onChange={(event) => setStringValue(setFormValues, "url", event.target.value)}
-              fullWidth
-              required
-            />
-            <TextField
-              label="Summary"
-              value={formValues.summary}
-              onChange={(event) => setStringValue(setFormValues, "summary", event.target.value)}
-              fullWidth
-              required
-              multiline
-              minRows={3}
-            />
-            <TextField
-              label="Description"
-              value={formValues.description}
-              onChange={(event) => setStringValue(setFormValues, "description", event.target.value)}
-              fullWidth
-              required
-              multiline
-              minRows={5}
-            />
-          </JobFieldSection>
-
-          <JobFieldSection title="Source">
-            <TextField
-              label="Source name"
-              value={formValues.sourceName}
-              onChange={(event) => setStringValue(setFormValues, "sourceName", event.target.value)}
-              fullWidth
-              required
-            />
-            <TextField
-              label="Source job ID"
-              value={formValues.sourceJobId}
-              onChange={(event) => setStringValue(setFormValues, "sourceJobId", event.target.value)}
-              fullWidth
-              required
-            />
-            <TextField
-              label="Source ad reference"
-              value={formValues.sourceAdReference ?? ""}
-              onChange={(event) =>
-                setNullableStringValue(setFormValues, "sourceAdReference", event.target.value)
-              }
-              fullWidth
-            />
-            <TextField
-              label="Job refresh run ID"
-              value={formValues.jobRefreshRunId ?? ""}
-              onChange={(event) =>
-                setNullableNumberValue(setFormValues, "jobRefreshRunId", event.target.value)
-              }
-              fullWidth
-            />
-            <TextField
-              label="Raw payload JSON"
-              value={formValues.rawPayloadJson}
-              onChange={(event) =>
-                setStringValue(setFormValues, "rawPayloadJson", event.target.value)
-              }
-              fullWidth
-              required
-              multiline
-              minRows={4}
-            />
-          </JobFieldSection>
-
-          <JobFieldSection title="Location">
-            <TextField
-              label="Postcode"
-              value={formValues.postcode}
-              onChange={(event) => setStringValue(setFormValues, "postcode", event.target.value)}
-              fullWidth
-              required
-            />
-            <TextField
-              label="Location name"
-              value={formValues.locationName}
-              onChange={(event) =>
-                setStringValue(setFormValues, "locationName", event.target.value)
-              }
-              fullWidth
-              required
-            />
-            <TextField
-              label="Location display name"
-              value={formValues.locationDisplayName ?? ""}
-              onChange={(event) =>
-                setNullableStringValue(setFormValues, "locationDisplayName", event.target.value)
-              }
-              fullWidth
-            />
-            <TextField
-              label="Location area JSON"
-              value={formValues.locationAreaJson ?? ""}
-              onChange={(event) =>
-                setNullableStringValue(setFormValues, "locationAreaJson", event.target.value)
-              }
-              fullWidth
-            />
-            <TextField
-              label="Latitude"
-              value={formValues.latitude ?? ""}
-              onChange={(event) =>
-                setNullableNumberValue(setFormValues, "latitude", event.target.value)
-              }
-              fullWidth
-            />
-            <TextField
-              label="Longitude"
-              value={formValues.longitude ?? ""}
-              onChange={(event) =>
-                setNullableNumberValue(setFormValues, "longitude", event.target.value)
-              }
-              fullWidth
-            />
-          </JobFieldSection>
-
-          <JobFieldSection title="Classification and salary">
-            <TextField
-              label="Category tag"
-              value={formValues.categoryTag ?? ""}
-              onChange={(event) =>
-                setNullableStringValue(setFormValues, "categoryTag", event.target.value)
-              }
-              fullWidth
-            />
-            <TextField
-              label="Category label"
-              value={formValues.categoryLabel ?? ""}
-              onChange={(event) =>
-                setNullableStringValue(setFormValues, "categoryLabel", event.target.value)
-              }
-              fullWidth
-            />
-            <TextField
-              label="Salary min"
-              value={formValues.salaryMin ?? ""}
-              onChange={(event) =>
-                setNullableNumberValue(setFormValues, "salaryMin", event.target.value)
-              }
-              fullWidth
-            />
-            <TextField
-              label="Salary max"
-              value={formValues.salaryMax ?? ""}
-              onChange={(event) =>
-                setNullableNumberValue(setFormValues, "salaryMax", event.target.value)
-              }
-              fullWidth
-            />
-            <TextField
-              label="Salary currency"
-              value={formValues.salaryCurrency ?? ""}
-              onChange={(event) =>
-                setNullableStringValue(setFormValues, "salaryCurrency", event.target.value)
-              }
-              fullWidth
-            />
-            <TextField
-              label="Contract time"
-              value={formValues.contractTime ?? ""}
-              onChange={(event) =>
-                setNullableStringValue(setFormValues, "contractTime", event.target.value)
-              }
-              fullWidth
-            />
-            <TextField
-              label="Contract type"
-              value={formValues.contractType ?? ""}
-              onChange={(event) =>
-                setNullableStringValue(setFormValues, "contractType", event.target.value)
-              }
-              fullWidth
-            />
-          </JobFieldSection>
-
-          <JobFieldSection title="Flags and timestamps">
-            <div className="grid gap-2 md:grid-cols-3">
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={formValues.isFullTime}
-                    onChange={(event) =>
-                      setBooleanValue(setFormValues, "isFullTime", event.target.checked)
-                    }
-                  />
-                }
-                label="Full time"
-              />
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={formValues.isPartTime}
-                    onChange={(event) =>
-                      setBooleanValue(setFormValues, "isPartTime", event.target.checked)
-                    }
-                  />
-                }
-                label="Part time"
-              />
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={formValues.isPermanent}
-                    onChange={(event) =>
-                      setBooleanValue(setFormValues, "isPermanent", event.target.checked)
-                    }
-                  />
-                }
-                label="Permanent"
-              />
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={formValues.isContract}
-                    onChange={(event) =>
-                      setBooleanValue(setFormValues, "isContract", event.target.checked)
-                    }
-                  />
-                }
-                label="Contract"
-              />
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={formValues.isRemote}
-                    onChange={(event) =>
-                      setBooleanValue(setFormValues, "isRemote", event.target.checked)
-                    }
-                  />
-                }
-                label="Remote"
-              />
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={formValues.isHidden}
-                    onChange={(event) =>
-                      setBooleanValue(setFormValues, "isHidden", event.target.checked)
-                    }
-                  />
-                }
-                label="Hidden"
-              />
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={formValues.salaryIsPredicted ?? false}
-                    onChange={(event) =>
-                      setNullableBooleanValue(
-                        setFormValues,
-                        "salaryIsPredicted",
-                        event.target.checked
-                      )
-                    }
-                  />
-                }
-                label="Salary predicted"
-              />
-            </div>
-            <TextField
-              label="Posted at UTC"
-              value={formValues.postedAtUtc}
-              onChange={(event) =>
-                setStringValue(setFormValues, "postedAtUtc", event.target.value)
-              }
-              fullWidth
-              required
-            />
-            <TextField
-              label="Imported at UTC"
-              value={formValues.importedAtUtc}
-              onChange={(event) =>
-                setStringValue(setFormValues, "importedAtUtc", event.target.value)
-              }
-              fullWidth
-              required
-            />
-            <TextField
-              label="Last seen at UTC"
-              value={formValues.lastSeenAtUtc}
-              onChange={(event) =>
-                setStringValue(setFormValues, "lastSeenAtUtc", event.target.value)
-              }
-              fullWidth
-              required
-            />
-          </JobFieldSection>
-
-          <SectionCard className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between">
-            <div className="text-sm text-foreground-secondary">
-              {isCreateMode
-                ? "Create a new job resource in the backend table."
-                : "Save changes, hide the job, or delete it after it has been hidden."}
-            </div>
-            <div className="flex flex-wrap gap-3">
-              {!isCreateMode ? (
-                <Button
-                  type="button"
-                  variant="outlined"
-                  color="inherit"
-                  startIcon={<VisibilityOffRoundedIcon />}
-                  disabled={!isAdmin || isHiding || isSaving || isDeleting}
-                  onClick={() => void handleHide()}
-                >
-                  {isHiding ? "Hiding..." : "Hide job"}
-                </Button>
-              ) : null}
-              {!isCreateMode ? (
-                <Button
-                  type="button"
-                  color="error"
-                  variant="outlined"
-                  startIcon={<DeleteOutlineRoundedIcon />}
-                  disabled={!isAdmin || isDeleting || isSaving || isHiding}
-                  onClick={() => void handleDelete()}
-                >
-                  {isDeleting ? "Deleting..." : "Delete job"}
-                </Button>
-              ) : null}
-              <Button
-                type="submit"
-                variant="contained"
-                startIcon={<SaveRoundedIcon />}
-                disabled={!isAdmin || isSaving || isHiding || isDeleting}
-                sx={{
-                  bgcolor: "accent.main",
-                  "&:hover": { bgcolor: "accent.dark" }
-                }}
-              >
-                {isSaving ? "Saving..." : isCreateMode ? "Create job" : "Save changes"}
-              </Button>
-            </div>
-          </SectionCard>
-        </form>
+        <JobEditorHeader
+          isCreateMode={isCreateMode}
+          jobId={numericJobId}
+          pageTitle={pageTitle}
+        />
+        <JobEditorAlerts
+          errorMessage={errorMessage}
+          isAdmin={isAdmin}
+          saveMessage={saveMessage}
+        />
+        <JobEditorForm
+          formValues={formValues}
+          isAdmin={isAdmin}
+          isCreateMode={isCreateMode}
+          isDeleting={isDeleting}
+          isHiding={isHiding}
+          isSaving={isSaving}
+          onDelete={() => void handleDelete()}
+          onHide={() => void handleHide()}
+          onSubmit={handleSubmit}
+          setFormValues={setFormValues}
+        />
       </div>
     </div>
-  );
-}
-
-function JobFieldSection({
-  children,
-  title
-}: {
-  children: ReactNode;
-  title: string;
-}) {
-  return (
-    <SectionCard className="p-6">
-      <h2 className="font-serif text-2xl font-semibold text-foreground">{title}</h2>
-      <div className="mt-5 grid gap-4 md:grid-cols-2">{children}</div>
-    </SectionCard>
   );
 }
 
@@ -763,59 +371,4 @@ function normalizeNullableString(value: string | null): string | null {
 
   const trimmed = value.trim();
   return trimmed ? trimmed : null;
-}
-
-function setStringValue<TKey extends keyof CreateJobRequestDto>(
-  setFormValues: Dispatch<SetStateAction<CreateJobRequestDto>>,
-  key: TKey,
-  value: CreateJobRequestDto[TKey]
-) {
-  setFormValues((current) => ({
-    ...current,
-    [key]: value
-  }));
-}
-
-function setNullableStringValue<TKey extends keyof CreateJobRequestDto>(
-  setFormValues: Dispatch<SetStateAction<CreateJobRequestDto>>,
-  key: TKey,
-  value: string
-) {
-  setFormValues((current) => ({
-    ...current,
-    [key]: value === "" ? null : value
-  }));
-}
-
-function setNullableNumberValue<TKey extends keyof CreateJobRequestDto>(
-  setFormValues: Dispatch<SetStateAction<CreateJobRequestDto>>,
-  key: TKey,
-  value: string
-) {
-  setFormValues((current) => ({
-    ...current,
-    [key]: value === "" ? null : Number(value)
-  }));
-}
-
-function setBooleanValue<TKey extends keyof CreateJobRequestDto>(
-  setFormValues: Dispatch<SetStateAction<CreateJobRequestDto>>,
-  key: TKey,
-  value: boolean
-) {
-  setFormValues((current) => ({
-    ...current,
-    [key]: value
-  }));
-}
-
-function setNullableBooleanValue<TKey extends keyof CreateJobRequestDto>(
-  setFormValues: Dispatch<SetStateAction<CreateJobRequestDto>>,
-  key: TKey,
-  value: boolean
-) {
-  setFormValues((current) => ({
-    ...current,
-    [key]: value
-  }));
 }

--- a/apps/web/src/features/search/components/SearchResults.tsx
+++ b/apps/web/src/features/search/components/SearchResults.tsx
@@ -1,3 +1,6 @@
+import ChevronLeftRoundedIcon from "@mui/icons-material/ChevronLeftRounded";
+import ChevronRightRoundedIcon from "@mui/icons-material/ChevronRightRounded";
+import { Button, MenuItem, TextField } from "@mui/material";
 import type { SearchStatus } from "@/features/search/types/search.types";
 import { JobCard } from "@/features/jobs/components/JobCard";
 import type { JobCardModel } from "@/features/jobs/types/job.types";
@@ -9,6 +12,10 @@ type SearchResultsProps = {
   totalCount: number;
   keyword: string;
   postcode: string;
+  pageIndex: number;
+  pageSize: number;
+  onPageChange: (pageIndex: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
 };
 
 export function SearchResults({
@@ -17,7 +24,11 @@ export function SearchResults({
   results,
   totalCount,
   keyword,
-  postcode
+  postcode,
+  pageIndex,
+  pageSize,
+  onPageChange,
+  onPageSizeChange
 }: SearchResultsProps) {
   if (status === "idle") {
     return (
@@ -84,6 +95,45 @@ export function SearchResults({
         {results.map((job) => (
           <JobCard key={job.id} job={job} />
         ))}
+      </div>
+
+      <div className="mt-6 flex flex-col gap-4 rounded-lg border border-border bg-background-elevated px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-sm text-foreground-secondary">
+          Page <span className="font-medium text-foreground">{pageIndex + 1}</span> of{" "}
+          <span className="font-medium text-foreground">{Math.max(1, Math.ceil(totalCount / pageSize))}</span>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <TextField
+            select
+            size="small"
+            label="Per page"
+            value={String(pageSize)}
+            onChange={(event) => onPageSizeChange(Number(event.target.value))}
+            sx={{ minWidth: 120 }}
+          >
+            <MenuItem value="20">20</MenuItem>
+            <MenuItem value="50">50</MenuItem>
+            <MenuItem value="100">100</MenuItem>
+          </TextField>
+          <Button
+            variant="outlined"
+            color="inherit"
+            startIcon={<ChevronLeftRoundedIcon />}
+            disabled={pageIndex === 0}
+            onClick={() => onPageChange(pageIndex - 1)}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="outlined"
+            color="inherit"
+            endIcon={<ChevronRightRoundedIcon />}
+            disabled={pageIndex + 1 >= Math.max(1, Math.ceil(totalCount / pageSize))}
+            onClick={() => onPageChange(pageIndex + 1)}
+          >
+            Next
+          </Button>
+        </div>
       </div>
     </>
   );

--- a/apps/web/src/features/search/hooks/useJobSearch.test.tsx
+++ b/apps/web/src/features/search/hooks/useJobSearch.test.tsx
@@ -24,15 +24,29 @@ describe("useJobSearch", () => {
     vi.clearAllMocks();
   });
 
-  it("stays idle when no criteria are provided", () => {
-    const { result } = renderHook(() => useJobSearch({ keyword: "", postcode: "" }));
-
-    expect(result.current).toEqual({
-      status: "idle",
-      data: null,
-      errorMessage: null
+  it("loads visible jobs even when no criteria are provided", async () => {
+    vi.mocked(getJobsPage).mockResolvedValueOnce({
+      pageIndex: 0,
+      pageSize: 20,
+      totalCount: 0,
+      items: []
     });
-    expect(getJobsPage).not.toHaveBeenCalled();
+
+    const { result } = renderHook(() =>
+      useJobSearch({ keyword: "", postcode: "", pageIndex: 0, pageSize: 20 })
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("empty");
+    });
+
+    expect(getJobsPage).toHaveBeenCalledWith({
+      pageIndex: 0,
+      pageSize: 20,
+      postcode: undefined,
+      keyword: undefined,
+      isHidden: false
+    });
   });
 
   it("loads and returns mapped results for a populated search", async () => {
@@ -42,7 +56,9 @@ describe("useJobSearch", () => {
     const { result } = renderHook(() =>
       useJobSearch({
         keyword: "designer",
-        postcode: "EC2A"
+        postcode: "EC2A",
+        pageIndex: 1,
+        pageSize: 50
       })
     );
 
@@ -52,7 +68,7 @@ describe("useJobSearch", () => {
 
     deferred.resolve({
       pageIndex: 0,
-      pageSize: 20,
+      pageSize: 50,
       totalCount: 1,
       items: [
         {
@@ -106,10 +122,14 @@ describe("useJobSearch", () => {
       location: "London",
       salary: "\u00a370,000 - \u00a390,000"
     });
+    expect(result.current.data).toMatchObject({
+      pageIndex: 0,
+      pageSize: 50
+    });
     expect(result.current.errorMessage).toBeNull();
     expect(getJobsPage).toHaveBeenCalledWith({
-      pageIndex: 0,
-      pageSize: 20,
+      pageIndex: 1,
+      pageSize: 50,
       postcode: "EC2A",
       keyword: "designer",
       isHidden: false
@@ -127,7 +147,9 @@ describe("useJobSearch", () => {
     const { result } = renderHook(() =>
       useJobSearch({
         keyword: "analyst",
-        postcode: "SE1"
+        postcode: "SE1",
+        pageIndex: 0,
+        pageSize: 20
       })
     );
 
@@ -144,7 +166,9 @@ describe("useJobSearch", () => {
     const { result } = renderHook(() =>
       useJobSearch({
         keyword: "engineer",
-        postcode: "M1"
+        postcode: "M1",
+        pageIndex: 0,
+        pageSize: 20
       })
     );
 

--- a/apps/web/src/features/search/hooks/useJobSearch.test.tsx
+++ b/apps/web/src/features/search/hooks/useJobSearch.test.tsx
@@ -1,10 +1,10 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { searchJobs } from "@/api/job-search/job-search.api";
+import { getJobsPage } from "@/api/jobs/jobs.api";
 import { useJobSearch } from "@/features/search/hooks/useJobSearch";
 
-vi.mock("@/api/job-search/job-search.api", () => ({
-  searchJobs: vi.fn()
+vi.mock("@/api/jobs/jobs.api", () => ({
+  getJobsPage: vi.fn()
 }));
 
 function createDeferred<T>() {
@@ -32,12 +32,12 @@ describe("useJobSearch", () => {
       data: null,
       errorMessage: null
     });
-    expect(searchJobs).not.toHaveBeenCalled();
+    expect(getJobsPage).not.toHaveBeenCalled();
   });
 
   it("loads and returns mapped results for a populated search", async () => {
-    const deferred = createDeferred<Awaited<ReturnType<typeof searchJobs>>>();
-    vi.mocked(searchJobs).mockReturnValueOnce(deferred.promise);
+    const deferred = createDeferred<Awaited<ReturnType<typeof getJobsPage>>>();
+    vi.mocked(getJobsPage).mockReturnValueOnce(deferred.promise);
 
     const { result } = renderHook(() =>
       useJobSearch({
@@ -51,22 +51,47 @@ describe("useJobSearch", () => {
     });
 
     deferred.resolve({
-      postcode: "EC2A",
-      keyword: "designer",
       pageIndex: 0,
       pageSize: 20,
       totalCount: 1,
-      jobs: [
+      items: [
         {
           id: 1,
+          jobRefreshRunId: null,
+          sourceJobId: "adz-1",
+          sourceAdReference: null,
           title: "Product Designer",
+          description: "Shape the MVP search flow.",
           company: "Firefly",
+          companyDisplayName: "Firefly",
+          companyCanonicalName: "firefly",
+          postcode: "EC2A",
           locationName: "London",
+          locationDisplayName: "London",
+          locationAreaJson: null,
+          latitude: null,
+          longitude: null,
+          categoryTag: "design",
+          categoryLabel: "Design",
           summary: "Shape the MVP search flow.",
           url: "https://example.com/jobs/1",
           sourceName: "Reed",
+          salaryMin: 70000,
+          salaryMax: 90000,
+          salaryCurrency: "GBP",
+          salaryIsPredicted: false,
+          contractTime: "full_time",
+          contractType: "permanent",
+          isFullTime: true,
+          isPartTime: false,
+          isPermanent: true,
+          isContract: false,
           isRemote: false,
-          postedAtUtc: "2025-01-02T09:00:00.000Z"
+          postedAtUtc: "2025-01-02T09:00:00.000Z",
+          importedAtUtc: "2025-01-02T10:00:00.000Z",
+          lastSeenAtUtc: "2025-01-02T11:00:00.000Z",
+          isHidden: false,
+          rawPayloadJson: "{}"
         }
       ]
     });
@@ -78,20 +103,25 @@ describe("useJobSearch", () => {
     expect(result.current.data?.jobs[0]).toMatchObject({
       id: "1",
       employer: "Firefly",
-      location: "London"
+      location: "London",
+      salary: "\u00a370,000 - \u00a390,000"
     });
     expect(result.current.errorMessage).toBeNull();
-    expect(searchJobs).toHaveBeenCalledWith("EC2A", "designer", "adzuna");
+    expect(getJobsPage).toHaveBeenCalledWith({
+      pageIndex: 0,
+      pageSize: 20,
+      postcode: "EC2A",
+      keyword: "designer",
+      isHidden: false
+    });
   });
 
   it("returns the empty state when the search succeeds without jobs", async () => {
-    vi.mocked(searchJobs).mockResolvedValueOnce({
-      postcode: "SE1",
-      keyword: "analyst",
+    vi.mocked(getJobsPage).mockResolvedValueOnce({
       pageIndex: 0,
       pageSize: 20,
       totalCount: 0,
-      jobs: []
+      items: []
     });
 
     const { result } = renderHook(() =>
@@ -109,7 +139,7 @@ describe("useJobSearch", () => {
   });
 
   it("surfaces API failures as an error state", async () => {
-    vi.mocked(searchJobs).mockRejectedValueOnce(new Error("Search service is unavailable."));
+    vi.mocked(getJobsPage).mockRejectedValueOnce(new Error("Search service is unavailable."));
 
     const { result } = renderHook(() =>
       useJobSearch({

--- a/apps/web/src/features/search/hooks/useJobSearch.ts
+++ b/apps/web/src/features/search/hooks/useJobSearch.ts
@@ -1,4 +1,4 @@
-import { searchJobs } from "@/api/job-search/job-search.api";
+import { getJobsPage } from "@/api/jobs/jobs.api";
 import { useCallback, useEffect } from "react";
 import type { SearchCriteria, SearchStatus, SearchViewModel } from "@/features/search/types/search.types";
 import { mapSearchResponse } from "@/features/search/mappers/search.mappers";
@@ -12,7 +12,16 @@ export const initialSearchState: SearchState = createAsyncState("idle");
 export function useJobSearch({ postcode, keyword }: SearchCriteria) {
   const runSearch = useCallback(
     async (nextPostcode: string, nextKeyword: string) =>
-      mapSearchResponse(await searchJobs(nextPostcode, nextKeyword, "adzuna")),
+      mapSearchResponse(
+        await getJobsPage({
+          pageIndex: 0,
+          pageSize: 20,
+          postcode: nextPostcode || undefined,
+          keyword: nextKeyword || undefined,
+          isHidden: false
+        }),
+        { postcode: nextPostcode, keyword: nextKeyword }
+      ),
     []
   );
   const { status, data, errorMessage, execute } = useAsyncTask(runSearch);

--- a/apps/web/src/features/search/hooks/useJobSearch.ts
+++ b/apps/web/src/features/search/hooks/useJobSearch.ts
@@ -9,13 +9,13 @@ type SearchState = AsyncState<SearchViewModel, SearchStatus>;
 
 export const initialSearchState: SearchState = createAsyncState("idle");
 
-export function useJobSearch({ postcode, keyword }: SearchCriteria) {
+export function useJobSearch({ postcode, keyword, pageIndex, pageSize }: SearchCriteria) {
   const runSearch = useCallback(
-    async (nextPostcode: string, nextKeyword: string) =>
+    async (nextPostcode: string, nextKeyword: string, nextPageIndex: number, nextPageSize: number) =>
       mapSearchResponse(
         await getJobsPage({
-          pageIndex: 0,
-          pageSize: 20,
+          pageIndex: nextPageIndex,
+          pageSize: nextPageSize,
           postcode: nextPostcode || undefined,
           keyword: nextKeyword || undefined,
           isHidden: false
@@ -25,19 +25,10 @@ export function useJobSearch({ postcode, keyword }: SearchCriteria) {
     []
   );
   const { status, data, errorMessage, execute } = useAsyncTask(runSearch);
-  const hasCriteria = Boolean(postcode || keyword);
 
   useEffect(() => {
-    if (!hasCriteria) {
-      return;
-    }
-
-    void execute(postcode, keyword);
-  }, [execute, hasCriteria, postcode, keyword]);
-
-  if (!hasCriteria) {
-    return initialSearchState;
-  }
+    void execute(postcode, keyword, pageIndex, pageSize);
+  }, [execute, pageIndex, pageSize, postcode, keyword]);
 
   return {
     status: status === "success" && data?.jobs.length === 0 ? "empty" : status,

--- a/apps/web/src/features/search/lib/search-query.test.ts
+++ b/apps/web/src/features/search/lib/search-query.test.ts
@@ -12,23 +12,31 @@ describe("search-query", () => {
     expect(
       normalizeSearchCriteria({
         keyword: "  frontend engineer  ",
-        postcode: "  SW1A 1AA  "
+        postcode: "  SW1A 1AA  ",
+        pageIndex: 2,
+        pageSize: 50
       })
     ).toEqual({
       keyword: "frontend engineer",
-      postcode: "SW1A 1AA"
+      postcode: "SW1A 1AA",
+      pageIndex: 2,
+      pageSize: 50
     });
   });
 
   it("reads and trims criteria from URL search params", () => {
     const params = new URLSearchParams({
       keyword: "  designer ",
-      postcode: " EC2A "
+      postcode: " EC2A ",
+      pageIndex: "3",
+      pageSize: "100"
     });
 
     expect(readSearchCriteria(params)).toEqual({
       keyword: "designer",
-      postcode: "EC2A"
+      postcode: "EC2A",
+      pageIndex: 3,
+      pageSize: 100
     });
   });
 
@@ -36,22 +44,42 @@ describe("search-query", () => {
     expect(
       createSearchParams({
         keyword: "  product manager  ",
-        postcode: "   "
+        postcode: "   ",
+        pageIndex: 0,
+        pageSize: 50
       }).toString()
-    ).toBe("keyword=product+manager");
+    ).toBe("keyword=product+manager&pageSize=50");
   });
 
   it("builds the search path from normalized criteria", () => {
     expect(
       createSearchPath({
         keyword: "  data scientist ",
-        postcode: " E1 "
+        postcode: " E1 ",
+        pageIndex: 2,
+        pageSize: 100
       })
-    ).toBe("/search?keyword=data+scientist&postcode=E1");
+    ).toBe("/search?keyword=data+scientist&postcode=E1&pageIndex=2&pageSize=100");
   });
 
   it("detects whether any search criteria are present", () => {
-    expect(hasSearchCriteria({ keyword: "", postcode: "" })).toBe(false);
-    expect(hasSearchCriteria({ keyword: "", postcode: "SE1" })).toBe(true);
+    expect(hasSearchCriteria({ keyword: "", postcode: "", pageIndex: 0, pageSize: 20 })).toBe(false);
+    expect(hasSearchCriteria({ keyword: "", postcode: "SE1", pageIndex: 0, pageSize: 20 })).toBe(true);
+  });
+
+  it("normalizes invalid paging values back to defaults", () => {
+    expect(
+      normalizeSearchCriteria({
+        keyword: "",
+        postcode: "",
+        pageIndex: -3,
+        pageSize: 999
+      })
+    ).toEqual({
+      keyword: "",
+      postcode: "",
+      pageIndex: 0,
+      pageSize: 20
+    });
   });
 });

--- a/apps/web/src/features/search/lib/search-query.ts
+++ b/apps/web/src/features/search/lib/search-query.ts
@@ -1,16 +1,24 @@
 import type { SearchCriteria } from "@/features/search/types/search.types";
 
+const defaultPageIndex = 0;
+const defaultPageSize = 20;
+const allowedPageSizes = new Set([20, 50, 100]);
+
 export function normalizeSearchCriteria(criteria: SearchCriteria): SearchCriteria {
   return {
     keyword: criteria.keyword.trim(),
-    postcode: criteria.postcode.trim()
+    postcode: criteria.postcode.trim(),
+    pageIndex: normalizePageIndex(criteria.pageIndex),
+    pageSize: normalizePageSize(criteria.pageSize)
   };
 }
 
 export function readSearchCriteria(searchParams: URLSearchParams): SearchCriteria {
   return normalizeSearchCriteria({
     keyword: searchParams.get("keyword") ?? "",
-    postcode: searchParams.get("postcode") ?? ""
+    postcode: searchParams.get("postcode") ?? "",
+    pageIndex: Number(searchParams.get("pageIndex") ?? defaultPageIndex),
+    pageSize: Number(searchParams.get("pageSize") ?? defaultPageSize)
   });
 }
 
@@ -26,6 +34,14 @@ export function createSearchParams(criteria: SearchCriteria): URLSearchParams {
     params.set("postcode", normalized.postcode);
   }
 
+  if (normalized.pageIndex > 0) {
+    params.set("pageIndex", String(normalized.pageIndex));
+  }
+
+  if (normalized.pageSize !== defaultPageSize) {
+    params.set("pageSize", String(normalized.pageSize));
+  }
+
   return params;
 }
 
@@ -38,4 +54,13 @@ export function createSearchPath(criteria: SearchCriteria): string {
 
 export function hasSearchCriteria(criteria: SearchCriteria): boolean {
   return criteria.keyword.length > 0 || criteria.postcode.length > 0;
+}
+
+function normalizePageIndex(value: number): number {
+  return Number.isFinite(value) && value >= 0 ? Math.floor(value) : defaultPageIndex;
+}
+
+function normalizePageSize(value: number): number {
+  const normalizedValue = Number.isFinite(value) ? Math.floor(value) : defaultPageSize;
+  return allowedPageSizes.has(normalizedValue) ? normalizedValue : defaultPageSize;
 }

--- a/apps/web/src/features/search/mappers/search.mappers.test.ts
+++ b/apps/web/src/features/search/mappers/search.mappers.test.ts
@@ -4,24 +4,52 @@ import { mapSearchResponse } from "@/features/search/mappers/search.mappers";
 describe("mapSearchResponse", () => {
   it("maps API jobs into the UI model", () => {
     const result = mapSearchResponse({
-      postcode: "EC2A",
-      keyword: "designer",
       pageIndex: 0,
       pageSize: 20,
       totalCount: 1,
-      jobs: [
+      items: [
         {
           id: 42,
+          jobRefreshRunId: null,
+          sourceJobId: "reed-42",
+          sourceAdReference: null,
           title: "Senior Product Designer",
+          description: "Lead product design across the platform.",
           company: "Firefly Labs",
+          companyDisplayName: "Firefly Labs",
+          companyCanonicalName: "firefly-labs",
+          postcode: "EC2A",
           locationName: "London",
+          locationDisplayName: "London",
+          locationAreaJson: null,
+          latitude: null,
+          longitude: null,
+          categoryTag: null,
+          categoryLabel: null,
           summary: "Lead product design across the platform.",
           url: "https://example.com/jobs/42",
           sourceName: "Reed",
+          salaryMin: 80000,
+          salaryMax: 95000,
+          salaryCurrency: "GBP",
+          salaryIsPredicted: false,
+          contractTime: "full_time",
+          contractType: "permanent",
+          isFullTime: true,
+          isPartTime: false,
+          isPermanent: true,
+          isContract: false,
           isRemote: true,
-          postedAtUtc: "2025-01-02T09:00:00.000Z"
+          postedAtUtc: "2025-01-02T09:00:00.000Z",
+          importedAtUtc: "2025-01-02T10:00:00.000Z",
+          lastSeenAtUtc: "2025-01-02T11:00:00.000Z",
+          isHidden: false,
+          rawPayloadJson: "{}"
         }
       ]
+    }, {
+      postcode: "EC2A",
+      keyword: "designer"
     });
 
     expect(result).toEqual({
@@ -37,7 +65,9 @@ describe("mapSearchResponse", () => {
           summary: "Lead product design across the platform.",
           url: "https://example.com/jobs/42",
           source: "Reed",
-          postedDate: "2 Jan 2025"
+          postedDate: "2 Jan 2025",
+          salary: "£80,000 - £95,000",
+          type: "permanent"
         }
       ]
     });
@@ -45,24 +75,52 @@ describe("mapSearchResponse", () => {
 
   it("falls back when the posted date is invalid", () => {
     const result = mapSearchResponse({
-      postcode: "M1",
-      keyword: "engineer",
       pageIndex: 0,
       pageSize: 20,
       totalCount: 1,
-      jobs: [
+      items: [
         {
-          id: "abc",
+          id: 99,
+          jobRefreshRunId: null,
+          sourceJobId: "linkedin-abc",
+          sourceAdReference: null,
           title: "Platform Engineer",
+          description: "Build internal tooling.",
           company: "Signal",
+          companyDisplayName: null,
+          companyCanonicalName: null,
+          postcode: "M1",
           locationName: "Manchester",
+          locationDisplayName: null,
+          locationAreaJson: null,
+          latitude: null,
+          longitude: null,
+          categoryTag: null,
+          categoryLabel: null,
           summary: "Build internal tooling.",
           url: "https://example.com/jobs/abc",
           sourceName: "LinkedIn",
+          salaryMin: null,
+          salaryMax: null,
+          salaryCurrency: null,
+          salaryIsPredicted: null,
+          contractTime: null,
+          contractType: null,
+          isFullTime: false,
+          isPartTime: false,
+          isPermanent: false,
+          isContract: false,
           isRemote: false,
-          postedAtUtc: "not-a-date"
+          postedAtUtc: "not-a-date",
+          importedAtUtc: "2025-01-02T10:00:00.000Z",
+          lastSeenAtUtc: "2025-01-02T11:00:00.000Z",
+          isHidden: false,
+          rawPayloadJson: "{}"
         }
       ]
+    }, {
+      postcode: "M1",
+      keyword: "engineer"
     });
 
     expect(result.jobs[0]?.postedDate).toBe("Date unavailable");

--- a/apps/web/src/features/search/mappers/search.mappers.test.ts
+++ b/apps/web/src/features/search/mappers/search.mappers.test.ts
@@ -55,6 +55,8 @@ describe("mapSearchResponse", () => {
     expect(result).toEqual({
       postcode: "EC2A",
       keyword: "designer",
+      pageIndex: 0,
+      pageSize: 20,
       totalCount: 1,
       jobs: [
         {

--- a/apps/web/src/features/search/mappers/search.mappers.ts
+++ b/apps/web/src/features/search/mappers/search.mappers.ts
@@ -9,6 +9,8 @@ export function mapSearchResponse(
   return {
     postcode: criteria.postcode,
     keyword: criteria.keyword,
+    pageIndex: response.pageIndex,
+    pageSize: response.pageSize,
     totalCount: response.totalCount,
     jobs: response.items.map(mapJobCard)
   };

--- a/apps/web/src/features/search/mappers/search.mappers.ts
+++ b/apps/web/src/features/search/mappers/search.mappers.ts
@@ -1,26 +1,33 @@
-import type { JobCardDto, SearchJobsResponseDto } from "@/api/job-search/job-search.types";
+import type { JobsPageResponseDto, JobDetailsResponseDto } from "@/api/jobs/jobs.types";
 import type { JobCardModel } from "@/features/jobs/types/job.types";
 import type { SearchViewModel } from "@/features/search/types/search.types";
 
-export function mapSearchResponse(response: SearchJobsResponseDto): SearchViewModel {
+export function mapSearchResponse(
+  response: JobsPageResponseDto,
+  criteria: { postcode: string; keyword: string }
+): SearchViewModel {
   return {
-    postcode: response.postcode,
-    keyword: response.keyword,
+    postcode: criteria.postcode,
+    keyword: criteria.keyword,
     totalCount: response.totalCount,
-    jobs: response.jobs.map(mapJobCard)
+    jobs: response.items.map(mapJobCard)
   };
 }
 
-function mapJobCard(job: JobCardDto): JobCardModel {
+function mapJobCard(job: JobDetailsResponseDto): JobCardModel {
   return {
     id: String(job.id),
     title: job.title,
-    employer: job.company,
-    location: job.isRemote ? `${job.locationName} · Remote` : job.locationName,
+    employer: job.companyDisplayName ?? job.company,
+    location: job.isRemote
+      ? `${job.locationDisplayName ?? job.locationName} · Remote`
+      : (job.locationDisplayName ?? job.locationName),
     summary: job.summary,
     url: job.url,
     source: job.sourceName,
-    postedDate: formatPostedDate(job.postedAtUtc)
+    postedDate: formatPostedDate(job.postedAtUtc),
+    salary: formatSalary(job.salaryMin, job.salaryMax, job.salaryCurrency),
+    type: formatJobType(job.contractType, job.isPermanent, job.isContract, job.isFullTime, job.isPartTime)
   };
 }
 
@@ -35,4 +42,56 @@ function formatPostedDate(value: string): string {
     month: "short",
     year: "numeric"
   }).format(date);
+}
+
+function formatSalary(
+  salaryMin: number | null,
+  salaryMax: number | null,
+  salaryCurrency: string | null
+): string | undefined {
+  if (salaryMin === null && salaryMax === null) {
+    return undefined;
+  }
+
+  const formatter = new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: salaryCurrency ?? "GBP",
+    maximumFractionDigits: 0
+  });
+
+  if (salaryMin !== null && salaryMax !== null) {
+    return `${formatter.format(salaryMin)} - ${formatter.format(salaryMax)}`;
+  }
+
+  return formatter.format(salaryMin ?? salaryMax ?? 0);
+}
+
+function formatJobType(
+  contractType: string | null,
+  isPermanent: boolean,
+  isContract: boolean,
+  isFullTime: boolean,
+  isPartTime: boolean
+): string | undefined {
+  if (contractType) {
+    return contractType.replaceAll("_", " ");
+  }
+
+  if (isPermanent) {
+    return "permanent";
+  }
+
+  if (isContract) {
+    return "contract";
+  }
+
+  if (isFullTime) {
+    return "full time";
+  }
+
+  if (isPartTime) {
+    return "part time";
+  }
+
+  return undefined;
 }

--- a/apps/web/src/features/search/types/search.types.ts
+++ b/apps/web/src/features/search/types/search.types.ts
@@ -3,11 +3,15 @@ import type { JobCardModel } from "@/features/jobs/types/job.types";
 export type SearchCriteria = {
   postcode: string;
   keyword: string;
+  pageIndex: number;
+  pageSize: number;
 };
 
 export type SearchViewModel = {
   postcode: string;
   keyword: string;
+  pageIndex: number;
+  pageSize: number;
   totalCount: number;
   jobs: JobCardModel[];
 };

--- a/apps/web/src/features/search/views/SearchLandingView.tsx
+++ b/apps/web/src/features/search/views/SearchLandingView.tsx
@@ -13,7 +13,7 @@ export function SearchLandingView() {
   const navigate = useNavigate();
 
   function handleSearch(postcode: string, keyword: string) {
-    void navigate(createSearchPath({ keyword, postcode }));
+    void navigate(createSearchPath({ keyword, postcode, pageIndex: 0, pageSize: 20 }));
   }
 
   return (

--- a/apps/web/src/features/search/views/SearchResultsView.tsx
+++ b/apps/web/src/features/search/views/SearchResultsView.tsx
@@ -6,7 +6,6 @@ import { SearchResultsToolbar } from "@/features/search/components/SearchResults
 import { useJobSearch } from "@/features/search/hooks/useJobSearch";
 import {
   createSearchParams,
-  hasSearchCriteria,
   readSearchCriteria
 } from "@/features/search/lib/search-query";
 
@@ -14,6 +13,10 @@ export function SearchResultsView() {
   const [searchParams, setSearchParams] = useSearchParams();
   const criteria = readSearchCriteria(searchParams);
   const { status, data, errorMessage } = useJobSearch(criteria);
+
+  function updateCriteria(nextCriteria: typeof criteria) {
+    setSearchParams(createSearchParams(nextCriteria));
+  }
 
   return (
     <div className="min-h-screen bg-background">
@@ -26,7 +29,12 @@ export function SearchResultsView() {
             initialKeyword={criteria.keyword}
             initialPostcode={criteria.postcode}
             onSearch={(nextKeyword, nextPostcode) => {
-              setSearchParams(createSearchParams({ keyword: nextKeyword, postcode: nextPostcode }));
+              updateCriteria({
+                ...criteria,
+                keyword: nextKeyword,
+                postcode: nextPostcode,
+                pageIndex: 0
+              });
             }}
           />
         </div>
@@ -37,12 +45,27 @@ export function SearchResultsView() {
 
         <main>
           <SearchResults
-            status={hasSearchCriteria(criteria) ? status : "idle"}
+            status={status}
             errorMessage={errorMessage}
             results={data?.jobs ?? []}
             totalCount={data?.totalCount ?? 0}
             keyword={criteria.keyword}
             postcode={criteria.postcode}
+            pageIndex={data?.pageIndex ?? criteria.pageIndex}
+            pageSize={data?.pageSize ?? criteria.pageSize}
+            onPageChange={(pageIndex) => {
+              updateCriteria({
+                ...criteria,
+                pageIndex
+              });
+            }}
+            onPageSizeChange={(pageSize) => {
+              updateCriteria({
+                ...criteria,
+                pageSize,
+                pageIndex: 0
+              });
+            }}
           />
         </main>
       </div>

--- a/apps/web/src/features/workspace/components/WorkspaceToolCard.tsx
+++ b/apps/web/src/features/workspace/components/WorkspaceToolCard.tsx
@@ -1,17 +1,39 @@
+import { Link } from "react-router-dom";
 import type { ReactNode } from "react";
 
 type WorkspaceToolCardProps = {
+  description?: string;
   icon: ReactNode;
   title: string;
+  to?: string;
 };
 
-export function WorkspaceToolCard({ icon, title }: WorkspaceToolCardProps) {
+export function WorkspaceToolCard({
+  description = "Coming soon",
+  icon,
+  title,
+  to
+}: WorkspaceToolCardProps) {
+  const className = "flex items-center gap-3 rounded-md bg-muted p-3 transition-colors hover:bg-muted/80";
+
+  if (to) {
+    return (
+      <Link to={to} className={className}>
+        <div className="text-foreground-tertiary">{icon}</div>
+        <div>
+          <p className="text-sm font-medium text-foreground">{title}</p>
+          <p className="text-xs text-foreground-tertiary">{description}</p>
+        </div>
+      </Link>
+    );
+  }
+
   return (
-    <div className="flex items-center gap-3 rounded-md bg-muted p-3">
+    <div className={className}>
       <div className="text-foreground-tertiary">{icon}</div>
       <div>
         <p className="text-sm font-medium text-foreground">{title}</p>
-        <p className="text-xs text-foreground-tertiary">Coming soon</p>
+        <p className="text-xs text-foreground-tertiary">{description}</p>
       </div>
     </div>
   );

--- a/apps/web/src/features/workspace/components/WorkspaceToolsPanel.tsx
+++ b/apps/web/src/features/workspace/components/WorkspaceToolsPanel.tsx
@@ -1,5 +1,6 @@
 import DescriptionRoundedIcon from "@mui/icons-material/DescriptionRounded";
 import ScheduleRoundedIcon from "@mui/icons-material/ScheduleRounded";
+import WorkOutlineRoundedIcon from "@mui/icons-material/WorkOutlineRounded";
 import { SectionCard } from "@/components/SectionCard";
 import { WorkspaceToolCard } from "@/features/workspace/components/WorkspaceToolCard";
 
@@ -8,6 +9,12 @@ export function WorkspaceToolsPanel() {
     <SectionCard className="p-6">
       <h2 className="font-serif text-xl font-semibold text-foreground">Career tools</h2>
       <div className="mt-4 space-y-3">
+        <WorkspaceToolCard
+          icon={<WorkOutlineRoundedIcon />}
+          title="Manage jobs"
+          description="Create, edit, hide, and delete tracked jobs."
+          to="/admin/manage-jobs"
+        />
         <WorkspaceToolCard icon={<DescriptionRoundedIcon />} title="Resume analysis" />
         <WorkspaceToolCard icon={<ScheduleRoundedIcon />} title="Interview prep" />
       </div>

--- a/apps/web/src/features/workspace/views/WorkspaceView.tsx
+++ b/apps/web/src/features/workspace/views/WorkspaceView.tsx
@@ -31,11 +31,11 @@ export function WorkspaceView() {
       return;
     }
 
-    void navigate(createSearchPath({ keyword, postcode: "" }));
+    void navigate(createSearchPath({ keyword, postcode: "", pageIndex: 0, pageSize: 20 }));
   }
 
   function handleSelectSearch(query: string) {
-    void navigate(createSearchPath({ keyword: query, postcode: "" }));
+    void navigate(createSearchPath({ keyword: query, postcode: "", pageIndex: 0, pageSize: 20 }));
   }
 
   return (

--- a/apps/web/src/lib/http/client.ts
+++ b/apps/web/src/lib/http/client.ts
@@ -24,7 +24,51 @@ export async function postJson<TResponse, TBody>(
   });
 }
 
+export async function putJson<TResponse, TBody>(
+  path: string,
+  body: TBody,
+  init?: Omit<RequestInit, "method" | "body">
+): Promise<TResponse> {
+  return requestJson<TResponse>(path, {
+    ...init,
+    method: "PUT",
+    body: JSON.stringify(body)
+  });
+}
+
+export async function deleteRequest(
+  path: string,
+  init?: Omit<RequestInit, "method">
+): Promise<void> {
+  await request(path, {
+    ...init,
+    method: "DELETE"
+  });
+}
+
+export async function deleteJson<TResponse, TBody>(
+  path: string,
+  body: TBody,
+  init?: Omit<RequestInit, "method" | "body">
+): Promise<TResponse> {
+  return requestJson<TResponse>(path, {
+    ...init,
+    method: "DELETE",
+    body: JSON.stringify(body)
+  });
+}
+
 async function requestJson<TResponse>(path: string, init: RequestInit): Promise<TResponse> {
+  const response = await request(path, init);
+
+  if (response.status === 204) {
+    return null as TResponse;
+  }
+
+  return (await response.json()) as TResponse;
+}
+
+async function request(path: string, init: RequestInit): Promise<Response> {
   const accessToken = readAccessToken();
   const response = await fetch(`${getApiBaseUrl()}${path}`, {
     ...init,
@@ -40,7 +84,7 @@ async function requestJson<TResponse>(path: string, init: RequestInit): Promise<
     throw new ApiError(await getErrorMessage(response), response.status);
   }
 
-  return (await response.json()) as TResponse;
+  return response;
 }
 
 async function getErrorMessage(response: Response): Promise<string> {

--- a/apps/web/src/routes/AppJobCreatePage.tsx
+++ b/apps/web/src/routes/AppJobCreatePage.tsx
@@ -1,0 +1,5 @@
+import { ManageJobView } from "@/features/jobs/views/ManageJobView";
+
+export function AppJobCreatePage() {
+  return <ManageJobView />;
+}

--- a/apps/web/src/routes/AppJobDetailPage.tsx
+++ b/apps/web/src/routes/AppJobDetailPage.tsx
@@ -1,0 +1,7 @@
+import { useParams } from "react-router-dom";
+import { ManageJobView } from "@/features/jobs/views/ManageJobView";
+
+export function AppJobDetailPage() {
+  const { jobId } = useParams<{ jobId: string }>();
+  return <ManageJobView jobId={jobId} />;
+}

--- a/apps/web/src/routes/AppJobsPage.tsx
+++ b/apps/web/src/routes/AppJobsPage.tsx
@@ -1,0 +1,5 @@
+import { JobsListView } from "@/features/jobs/views/JobsListView";
+
+export function AppJobsPage() {
+  return <JobsListView />;
+}


### PR DESCRIPTION
## Summary
- add admin job management pages backed by the persisted jobs CRUD APIs, including table-based browsing, edit flows, and bulk hide/delete actions
- update public job search to use the paged persisted jobs API, support empty-filter browsing, and add pagination with page-size selection
- tighten route protection for admin pages and split the larger admin management views and editor form into smaller feature-owned components

## Validation
- npm test
- npm run lint
- npm run build

Closes #26