### PR TITLE
refactor(web): lazy load route screens (#29)

### DIFF
--- a/apps/web/src/app/AppRouter.tsx
+++ b/apps/web/src/app/AppRouter.tsx
@@ -1,14 +1,49 @@
-import { AdminRoute } from "@/features/auth/components/AdminRoute";
+import { Suspense, lazy } from "react";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
+import { RouteLoadingScreen } from "@/app/RouteLoadingScreen";
+import { AdminRoute } from "@/features/auth/components/AdminRoute";
 import { ProtectedRoute } from "@/features/auth/components/ProtectedRoute";
-import { AppJobCreatePage } from "@/routes/AppJobCreatePage";
-import { AppJobDetailPage } from "@/routes/AppJobDetailPage";
-import { AppJobsPage } from "@/routes/AppJobsPage";
-import { AppHomePage } from "@/routes/AppHomePage";
-import { JobDetailPage } from "@/routes/JobDetailPage";
-import { LoginPage } from "@/routes/LoginPage";
 import { SearchPage } from "@/routes/SearchPage";
-import { SearchResultsPage } from "@/routes/SearchResultsPage";
+
+const SearchResultsPage = lazy(() =>
+  import("@/routes/SearchResultsPage").then((module) => ({
+    default: module.SearchResultsPage
+  }))
+);
+const LoginPage = lazy(() =>
+  import("@/routes/LoginPage").then((module) => ({
+    default: module.LoginPage
+  }))
+);
+const JobDetailPage = lazy(() =>
+  import("@/routes/JobDetailPage").then((module) => ({
+    default: module.JobDetailPage
+  }))
+);
+const AppHomePage = lazy(() =>
+  import("@/routes/AppHomePage").then((module) => ({
+    default: module.AppHomePage
+  }))
+);
+const AppJobsPage = lazy(() =>
+  import("@/routes/AppJobsPage").then((module) => ({
+    default: module.AppJobsPage
+  }))
+);
+const AppJobCreatePage = lazy(() =>
+  import("@/routes/AppJobCreatePage").then((module) => ({
+    default: module.AppJobCreatePage
+  }))
+);
+const AppJobDetailPage = lazy(() =>
+  import("@/routes/AppJobDetailPage").then((module) => ({
+    default: module.AppJobDetailPage
+  }))
+);
+
+function withRouteFallback(page: React.ReactNode) {
+  return <Suspense fallback={<RouteLoadingScreen />}>{page}</Suspense>;
+}
 
 const router = createBrowserRouter([
   {
@@ -17,21 +52,21 @@ const router = createBrowserRouter([
   },
   {
     path: "/search",
-    element: <SearchResultsPage />
+    element: withRouteFallback(<SearchResultsPage />)
   },
   {
     path: "/login",
-    element: <LoginPage />
+    element: withRouteFallback(<LoginPage />)
   },
   {
     path: "/jobs/:jobId",
-    element: <JobDetailPage />
+    element: withRouteFallback(<JobDetailPage />)
   },
   {
     path: "/app",
     element: (
       <ProtectedRoute>
-        <AppHomePage />
+        {withRouteFallback(<AppHomePage />)}
       </ProtectedRoute>
     )
   },
@@ -39,7 +74,7 @@ const router = createBrowserRouter([
     path: "/admin/manage-jobs",
     element: (
       <AdminRoute>
-        <AppJobsPage />
+        {withRouteFallback(<AppJobsPage />)}
       </AdminRoute>
     )
   },
@@ -47,7 +82,7 @@ const router = createBrowserRouter([
     path: "/admin/manage-jobs/new",
     element: (
       <AdminRoute>
-        <AppJobCreatePage />
+        {withRouteFallback(<AppJobCreatePage />)}
       </AdminRoute>
     )
   },
@@ -55,7 +90,7 @@ const router = createBrowserRouter([
     path: "/admin/manage-jobs/:jobId",
     element: (
       <AdminRoute>
-        <AppJobDetailPage />
+        {withRouteFallback(<AppJobDetailPage />)}
       </AdminRoute>
     )
   }

--- a/apps/web/src/app/RouteLoadingScreen.tsx
+++ b/apps/web/src/app/RouteLoadingScreen.tsx
@@ -1,0 +1,19 @@
+import { CircularProgress } from "@mui/material";
+
+export function RouteLoadingScreen() {
+  return (
+    <div className="min-h-screen bg-background-base text-foreground">
+      <div className="flex min-h-screen items-center justify-center px-6">
+        <div className="flex max-w-sm flex-col items-center gap-4 text-center">
+          <CircularProgress color="inherit" size={28} />
+          <div>
+            <p className="font-serif text-2xl font-semibold">Loading screen</p>
+            <p className="mt-2 text-sm text-foreground-secondary">
+              Fetching the next Firefly Signal view.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add route-level lazy loading for heavier screens in the web router
- introduce a shared suspense fallback screen for route chunk loading
- keep route entry files thin while splitting admin, workspace, login, job detail, and search-results code out of the initial bundle

## Validation
- npm test
- npm run lint
- npm run build

## Result
- the previous Vite 500 kB chunk warning is gone
- the initial entry bundle now builds at 160.57 kB, with heavier screens emitted as separate chunks

Closes #29