### PR TITLE
docs(product): clarify MVP requirements and planning docs (#35)

### DIFF
--- a/docs/backend-designs.md
+++ b/docs/backend-designs.md
@@ -1,9 +1,9 @@
 # Backend Design
 
 ## Objectives
-- Support a web-first career intelligence product with a clean path to future mobile clients.
+- Support a web-first personal career intelligence product with a clean path to future mobile clients.
 - Keep initial operations simple while preserving clear backend boundaries.
-- Make local development reliable with Docker and production deployment practical on a Mac mini.
+- Make the MVP capable of storing and managing the full personal workflow, not only transient search.
 
 ## Detailed Reference Docs
 Use the files in `docs/backend-designs/` as the detailed backend source of truth for implementation style:
@@ -15,6 +15,7 @@ Use the files in `docs/backend-designs/` as the detailed backend source of truth
 - `local-docker-and-compose.md`
 - `identity-api-direction.md`
 - `adzuna-api.md`
+- `data-model-plan.md`
 
 ## High-Level Architecture
 The backend should start as a small set of focused .NET 10 services behind a gateway:
@@ -22,57 +23,56 @@ The backend should start as a small set of focused .NET 10 services behind a gat
   - public entry point exposed through Cloudflare Tunnel
   - routing, auth enforcement, request correlation, and cross-cutting concerns
 - `Identity API`
-  - seeded local account flow first, with Google OAuth added next
+  - seeded local account flow first, with Google OAuth added later if still needed
   - JWT issuance
-  - user CRUD and current-user/auth endpoints
-- `Job Search Service`
-  - provider-backed job search slice for live search
-  - orchestrates provider lookups, normalization, ranking basics, and optional future persistence
+  - user CRUD, current-user/auth endpoints, role claims, and user profile ownership
+- `Job Search API`
+  - provider-backed ingestion and persisted job catalog
+  - admin job management, search, filtering, sorting, save/apply/reject workflow, and AI result persistence
 - `AI API`
-  - hosts no-op AI endpoints first
-  - consumes RabbitMQ integration events for future enrichment workflows
+  - bounded job-fit and explanation endpoints
+  - may use RabbitMQ later for asynchronous enrichment, but should start with explicit workflow contracts
 - Future services only when needed
-  - profile service
-  - job tracking service
-  - AI workflow service
   - document service
+  - profile service
+  - AI workflow service
 
-This should behave like a deliberate, modular platform rather than a fragmented fleet of services.
+For the MVP, prefer extending the current Identity and Job Search services instead of immediately introducing more deployable services.
 
 ## Early Service Boundary Recommendation
 Start with four deployable backend components:
 1. API gateway
 2. Identity API
-3. Job search service
+3. Job Search API
 4. AI API
 
-Keep the rest documented but unimplemented until the product proves the need.
+Keep document and profile capabilities inside existing service boundaries until there is real pressure to split them out.
 
 ## Request Flow
-1. Web client sends request to Cloudflare-hosted domain.
+1. Web client sends request to the Cloudflare-hosted domain.
 2. Cloudflare routes API traffic through Tunnel to the Mac mini.
 3. Gateway authenticates the request and forwards it to the appropriate backend service.
-4. Identity API handles sign-in and token issuance for auth flows.
-5. Job search service queries external job sources, normalizes results, and returns a stable contract.
-6. Gateway returns a client-safe response with traceable metadata for logs and diagnostics.
+4. Identity API handles sign-in, token issuance, user-role claims, and profile ownership concerns.
+5. Job Search API stores imported jobs, handles search and workflow state, and persists user-linked AI results.
+6. AI API evaluates selected jobs against user profile material when requested.
+7. Gateway returns client-safe responses with traceable metadata for logs and diagnostics.
 
 ## Technology Decisions
 - Runtime: .NET 10
 - Persistence: PostgreSQL via EF Core
 - Messaging: RabbitMQ for asynchronous workflows only
 - Caching or transient coordination: Redis only where it solves a specific problem
-- Auth: Google OAuth using Gmail identity, issuing JWTs for API calls
+- Auth: seeded local auth first, with room for Google OAuth later
 - Deployment: Docker containers on a Mac mini
 - Public exposure: Cloudflare Tunnel
 
 ## Design Principles
 - Use vertical slices within each service.
 - Keep application logic independent of transport and persistence details.
-- Share contracts carefully; avoid a premature shared-kernel dependency tangle.
 - Favor explicit DTOs at service boundaries.
-- Centralize logging, tracing, and auth middleware patterns.
+- Centralize logging, tracing, auth, and permission patterns.
 - Prefer synchronous APIs first; add messaging when business flow truly benefits.
-- Use a repo-owned event bus abstraction with explicit subscriptions instead of a large broker framework.
+- Model the real personal workflow directly instead of hiding it behind placeholder abstractions.
 
 ## Suggested Solution Structure
 ```text
@@ -98,55 +98,51 @@ services/api/
     Firefly.Signal.JobSearch.FunctionalTests/
 ```
 
-This keeps Clean Architecture boundaries available without forcing every future service to share one rigid template.
-
 ## Data Strategy
 ### PostgreSQL
-Use PostgreSQL for:
-- persisted searches or saved jobs when introduced
-- normalized job records when persistence becomes necessary
-- user profile or preference data later
+Use PostgreSQL as a first-class source of truth for the MVP for:
+- user accounts and roles
+- user profile information
+- document metadata
+- imported and normalized job records
+- save/apply/reject workflow state
+- application notes
+- AI rating and explanation records
 
-Do not make PostgreSQL the required source of truth for the first live search flow.
-Introduce durable job storage only when a concrete persistence use case is real.
+The MVP is not a stateless search-only product.
+Persisted workflow data is part of the core requirement.
+
+### File Storage
+Use a simple local-first file storage approach for uploaded CVs, cover letters, and other user files during the MVP.
+Persist document metadata in PostgreSQL and keep storage implementation easy to replace later.
 
 ### Redis
 Use Redis only if needed for:
-- short-lived caching of external job queries
+- external provider result caching
 - rate-limit support
-- distributed locks or short-lived coordination
-
-Do not make Redis mandatory for the first end-to-end slice unless a concrete need appears.
+- short-lived coordination around provider ingestion or AI execution
 
 ### RabbitMQ
 Use RabbitMQ when:
-- background enrichment is valuable
-- scheduled or batch collection is introduced
-- non-blocking AI workflows are added
+- provider ingestion becomes scheduled or asynchronous
+- AI analysis needs background batch processing
+- import and enrichment workflows benefit from decoupling
 
-Keep the first synchronous search flow free of messaging if possible.
-
-Current repo messaging shape:
-- publishers depend on `Firefly.Signal.EventBus`
-- RabbitMQ implementation lives in `Firefly.Signal.EventBusRabbitMQ`
-- events are published to one durable direct exchange
-- each consuming API owns one durable queue named by `SubscriptionClientName`
-- handlers are registered explicitly with `AddSubscription<TEvent, THandler>()`
-- keep request-response flows on HTTP; use RabbitMQ for asynchronous side effects and downstream processing
+Do not force async workflows into the first implementation if synchronous request flows are still clear and manageable.
 
 ## Authentication And Authorization
-- Use Google OAuth for sign-in, anchored to Gmail identity.
-- Exchange validated identity for backend-issued JWTs.
+- Support at least `admin` and `test-admin` roles.
+- `admin` can perform backend write operations.
+- `test-admin` should see the same frontend areas but be restricted to backend read-only access.
 - Keep JWT generation and validation centralized.
-- Start with a single-user or low-user-count assumption, but avoid hard-coding identity shortcuts that block later expansion.
-- Design role and permission claims lightly even if only one user exists initially.
+- Model permission behavior explicitly instead of relying on frontend-only restrictions.
 
 ## API Design Guidance
 - Version public APIs from the start, even if only `v1`.
-- Return stable result models for job cards and detail expansions.
+- Return stable result models for job cards, job detail, workflow lists, user profile data, and AI outputs.
 - Normalize provider-specific quirks before they reach the frontend.
-- Include paging and source metadata in search responses.
-- Design idempotent endpoints where practical.
+- Keep search, workflow, profile, and AI contracts explicit and typed.
+- Design bulk admin and AI-selection workflows carefully so they remain reviewable and auditable.
 
 ## Operational Guidance
 - Use Docker Compose locally for PostgreSQL, pgweb, RabbitMQ, Redis, and service containers when they exist.
@@ -159,29 +155,33 @@ Current repo messaging shape:
 - Unit tests for domain and application logic
 - Integration tests for persistence and service boundaries
 - Contract tests around gateway-to-service behavior when multiple services exist
-- Keep end-to-end tests lean and focused on critical flows
+- Functional tests around auth, job management, search, and personal workflow endpoints
 
 ## Phased Backend Implementation
 ### Phase 1
-- Create the solution structure
-- Create gateway, identity API, and job search service shells
-- Add configuration, health checks, logging, and test projects
+- Formalize user roles and permission rules
+- Add user profile and document metadata persistence
+- Keep auth flows simple but explicit
 
 ### Phase 2
-- Implement search contract and first provider integration
-- Add JWT auth flow and secure gateway forwarding
-- Introduce Docker Compose for local dependencies
+- Persist imported jobs and provider refresh runs
+- Add admin CRUD and moderation workflows for jobs
+- Add deduplication and provider auditability
 
 ### Phase 3
-- Add persistence only when needed
-- Introduce caching if search behavior justifies it
-- Add RabbitMQ-backed workflows for async enrichment or collection
+- Add stored search, filtering, sorting, and postcode-distance support
+- Add personal save/apply/reject workflow data
+- Add notes and application document linkage
+
+### Phase 4
+- Add AI analysis contracts, persistence, and bounded execution flow
+- Move long-running work to RabbitMQ only if needed
 
 ## Open Questions
-- Which public job sources are acceptable for the MVP from a reliability and terms perspective?
-- Should the first release persist searches and results, or stay stateless?
-- Is the gateway a thin reverse proxy plus auth layer, or should it also perform lightweight response shaping?
+- Which provider or providers should be implemented first for dependable UK developer-job coverage?
+- Should uploaded document binaries stay on local disk for the full MVP, or move earlier to a managed object store?
+- Does postcode-distance filtering rely on a local postcode lookup dataset, an external postcode API, or both?
 
 ## Current Recommendation
-Favor a thin gateway, a lightweight identity API, and one real backend service first.
-That gives you a microservice-compatible starting point without paying the full coordination cost before the first product loop is proven.
+Favor a thin gateway, a lightweight identity API, one strong job-search/workflow service, and a bounded AI API.
+That matches the current codebase, supports the real MVP, and keeps the system understandable for one maintainer and outside reviewers.

--- a/docs/backend-designs/data-model-plan.md
+++ b/docs/backend-designs/data-model-plan.md
@@ -1,0 +1,311 @@
+# Backend Data Model Plan
+
+This document captures the recommended MVP data model shape for Firefly Signal based on the current product requirements.
+It is a planning document, not a migration contract.
+
+## Goals
+- Model the real personal-use workflow directly.
+- Keep ownership boundaries understandable inside the current service layout.
+- Support small, reviewable implementation issues without painting the product into a corner.
+
+## Service Ownership Recommendation
+### Identity API
+Own:
+- user accounts
+- roles and permission claims
+- user profile information
+- user-owned document metadata
+
+### Job Search API
+Own:
+- provider refresh runs
+- imported job postings
+- search and filtering support data
+- user job workflow state such as saved, applied, and rejected
+- application notes
+- application-to-document linkage
+- persisted AI outputs linked to jobs and users
+
+### AI API
+Own:
+- execution logic and prompt orchestration
+- request and response contracts for job-fit analysis
+
+Do not make the AI API the system of record for persisted AI outcomes.
+Persist the durable result records in the Job Search API domain.
+
+## Identity Domain Entities
+### UserAccount
+Purpose:
+- authentication identity and role ownership
+
+Core fields:
+- `Id`
+- `UserAccountName`
+- `PasswordHash`
+- `Email`
+- `DisplayName`
+- `Role`
+- audit fields
+
+Notes:
+- roles should support at least `admin` and `test-admin`
+- `test-admin` should be treated as read-only for backend mutations
+
+### UserProfile
+Purpose:
+- store the user's personal context for job selection and AI assistance
+
+Core fields:
+- `Id`
+- `UserAccountId`
+- `FullName`
+- `PreferredTitle`
+- `PrimaryLocationPostcode`
+- `LinkedInUrl`
+- `GithubUrl`
+- `PortfolioUrl`
+- `Summary`
+- `SkillsText`
+- `ExperienceText`
+- `PreferencesJson`
+- audit fields
+
+Notes:
+- keep the initial profile flexible
+- avoid over-normalizing profile details until real usage proves the need
+
+### UserDocument
+Purpose:
+- store metadata for uploaded CVs, cover letters, and supporting documents
+
+Core fields:
+- `Id`
+- `UserAccountId`
+- `DocumentType`
+- `DisplayName`
+- `OriginalFileName`
+- `StorageKey`
+- `ContentType`
+- `FileSizeBytes`
+- `ChecksumSha256`
+- `IsDefault`
+- `UploadedAtUtc`
+- audit fields
+
+Recommended `DocumentType` values:
+- `cv`
+- `cover-letter`
+- `profile-supporting`
+- `other`
+
+Notes:
+- store binary files outside the relational row
+- keep metadata in PostgreSQL
+
+## Job Search Domain Entities
+### JobRefreshRun
+Purpose:
+- track each import or refresh operation from a provider
+
+Core fields:
+- `Id`
+- `RequestedByUserAccountId`
+- `ProviderKind`
+- `SourceMode` (`api` or `scrape`)
+- `Status`
+- `StartedAtUtc`
+- `CompletedAtUtc`
+- `ImportedCount`
+- `UpdatedCount`
+- `HiddenCount`
+- `FailureSummary`
+- audit fields
+
+### JobPosting
+Purpose:
+- normalized persisted job record
+
+Existing code already contains most of this shape.
+
+Additional planning considerations:
+- add a durable deduplication key
+- preserve provider identity and raw payload
+- keep latitude and longitude when available
+- keep postcode and normalized location fields to support postcode-distance filtering
+
+Potential future fields:
+- `DeduplicationKey`
+- `SalaryText`
+- `LastAnalyzedAtUtc`
+
+### PostcodeLookupCache
+Purpose:
+- support postcode-distance filtering
+
+Core fields:
+- `Id`
+- `Postcode`
+- `Latitude`
+- `Longitude`
+- `Source`
+- `LastVerifiedAtUtc`
+
+Notes:
+- this may be a table, cache, or imported reference dataset depending on implementation choice
+- the important requirement is that postcode-to-coordinate resolution is reliable enough for search filtering
+
+### UserJobState
+Purpose:
+- store per-user relationship to a job in the personal workflow
+
+Core fields:
+- `Id`
+- `UserAccountId`
+- `JobPostingId`
+- `State`
+- `SavedAtUtc`
+- `AppliedAtUtc`
+- `RejectedAtUtc`
+- `LastUpdatedAtUtc`
+- audit fields
+
+Recommended `State` values:
+- `saved`
+- `applied`
+- `rejected`
+
+Notes:
+- this should be user-specific
+- avoid overloading the core `JobPosting` row with user workflow state
+
+### JobApplication
+Purpose:
+- hold richer application details once a user has applied
+
+Core fields:
+- `Id`
+- `UserAccountId`
+- `JobPostingId`
+- `AppliedAtUtc`
+- `Status`
+- `SubmittedCvDocumentId`
+- `SubmittedCoverLetterDocumentId`
+- `RejectionAtUtc`
+- `RejectionReason`
+- audit fields
+
+Recommended `Status` values:
+- `applied`
+- `rejected`
+
+Notes:
+- this can coexist with `UserJobState`
+- keep it focused on applied-job metadata rather than becoming a full ATS system
+
+### ApplicationNote
+Purpose:
+- store personal notes attached to an application
+
+Core fields:
+- `Id`
+- `JobApplicationId`
+- `UserAccountId`
+- `Body`
+- `CreatedAtUtc`
+- `UpdatedAtUtc`
+
+### ApplicationDocumentLink
+Purpose:
+- link additional user-owned documents to an application
+
+Core fields:
+- `Id`
+- `JobApplicationId`
+- `UserDocumentId`
+- `LinkType`
+- audit fields
+
+Recommended `LinkType` values:
+- `submitted-cv`
+- `submitted-cover-letter`
+- `supporting-document`
+
+### UserJobAiInsight
+Purpose:
+- persist AI-generated job-fit results linked to a specific user and job
+
+Core fields:
+- `Id`
+- `UserAccountId`
+- `JobPostingId`
+- `GeneratedByUserAccountId`
+- `Rating`
+- `Summary`
+- `DetailedExplanation`
+- `CvImprovementSuggestions`
+- `PromptVersion`
+- `GeneratedAtUtc`
+- audit fields
+
+Rules:
+- `Rating` must be constrained to 1 through 5
+- results are user-specific
+- results should be treated as assistance, not authoritative truth
+
+### AiAnalysisRun
+Purpose:
+- track bulk or multi-job AI requests initiated from admin workflows
+
+Core fields:
+- `Id`
+- `RequestedByUserAccountId`
+- `TargetUserAccountId`
+- `Mode`
+- `Status`
+- `JobCount`
+- `StartedAtUtc`
+- `CompletedAtUtc`
+- `FailureSummary`
+
+Recommended `Mode` values:
+- `rating`
+- `detailed`
+- `cv-improvement`
+
+## Key Relationships
+- `UserAccount` 1-to-1 `UserProfile`
+- `UserAccount` 1-to-many `UserDocument`
+- `JobRefreshRun` 1-to-many `JobPosting`
+- `UserAccount` 1-to-many `UserJobState`
+- `JobPosting` 1-to-many `UserJobState`
+- `UserAccount` 1-to-many `JobApplication`
+- `JobPosting` 1-to-many `JobApplication`
+- `JobApplication` 1-to-many `ApplicationNote`
+- `JobApplication` 1-to-many `ApplicationDocumentLink`
+- `UserDocument` 1-to-many `ApplicationDocumentLink`
+- `UserAccount` 1-to-many `UserJobAiInsight`
+- `JobPosting` 1-to-many `UserJobAiInsight`
+- `AiAnalysisRun` 1-to-many `UserJobAiInsight`
+
+## Boundary Rules
+- Keep auth and profile ownership in Identity.
+- Keep persisted job and personal workflow state in Job Search.
+- Keep AI execution logic in AI, but persist durable AI outputs in Job Search.
+- Use user IDs as explicit cross-service references instead of hiding them behind vague shared abstractions.
+
+## Sequencing Recommendation
+Implement in this order:
+1. `UserProfile`
+2. `UserDocument`
+3. `JobRefreshRun` hardening and `JobPosting` persistence/deduplication
+4. `UserJobState`
+5. `JobApplication`
+6. `ApplicationNote`
+7. `ApplicationDocumentLink`
+8. `UserJobAiInsight`
+9. `AiAnalysisRun`
+
+## Current Recommendation
+Use a small set of explicit, user-owned workflow entities rather than trying to encode the whole product inside `JobPosting` or `UserAccount`.
+That will keep the MVP understandable and make later issues easier to scope cleanly.

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -7,7 +7,7 @@ What should we build next, in what order, and how do we keep those changes small
 
 ## Why This Folder Exists
 
-The source-of-truth docs already define the product direction and architecture:
+The source-of-truth docs define the product direction and architecture:
 - `docs/product-requirements-document.md`
 - `docs/frontend-designs.md`
 - `docs/backend-designs.md`
@@ -21,14 +21,14 @@ This folder adds the development lens:
 
 ## Current Baseline
 
-At the time this folder was created, the repository already includes:
-- a React web app with a search experience and supporting tests
+The repository already includes:
+- a React web app with public search, login, protected routes, and admin job-management UI
 - a .NET backend with gateway, identity, job search, and AI APIs
 - local Docker Compose support for backend dependencies
 - repo conventions for GitHub issue-driven delivery
 
 That means future planning should not treat the repo as an empty scaffold.
-The next issues should refine and connect what already exists.
+The next issues should connect and harden what already exists around the real MVP workflow.
 
 ## How To Use These Docs
 
@@ -36,9 +36,10 @@ Read in this order before starting a larger implementation issue:
 
 1. `docs/product-requirements-document.md`
 2. `docs/plans.md`
-3. `docs/development/roadmap.md`
-4. `docs/development/todo.md`
-5. the relevant area design doc:
+3. `docs/backend-designs/data-model-plan.md`
+4. `docs/development/roadmap.md`
+5. `docs/development/todo.md`
+6. the relevant area design doc:
    - `docs/frontend-designs.md`
    - `docs/backend-designs.md`
    - `docs/github-delivery/overview.md`
@@ -48,7 +49,7 @@ Read in this order before starting a larger implementation issue:
 - Keep each issue small enough for one branch and one reviewable PR.
 - Prefer vertical slices over broad platform work.
 - Use the current repo state as the starting point, not the original empty-repo vision.
-- Prioritize work that improves the real search loop before adding optional platform complexity.
+- Prioritize the real personal-use workflow: persisted job catalog, search, workflow state, profile, documents, and bounded AI support.
 - Update these docs when implementation changes the recommended order or introduces a durable new constraint.
 
 ## Folder Contents
@@ -56,10 +57,10 @@ Read in this order before starting a larger implementation issue:
 - `roadmap.md`
   Recommended development sequence from the current baseline.
 - `todo.md`
-  Candidate issues and follow-up work, grouped by priority and area.
+  Prioritized working backlog and candidate future issues.
 
 ## Current Recommendation
 
 The most important planning principle for this repo is:
 
-Strengthen the first useful job-search loop end to end before expanding into richer persistence, AI workflows, or automation layers.
+Strengthen the real single-user end-to-end product loop before expanding into advanced user-management or mobile-platform work.

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -1,134 +1,105 @@
 # Development Roadmap
 
 This roadmap translates the repository's current state and intended direction into a practical implementation sequence.
-It is intentionally biased toward getting to a usable MVP first, then hardening and expanding the platform without prematurely over-engineering it.
+It is intentionally biased toward delivering the real personal-use MVP, not a narrow demo that will later need to be rebuilt.
 
 ## Planning Assumptions
 
 - The web app is the primary client for the first release.
 - The current codebase already contains an initial frontend search flow and backend service shells.
-- Authentication should exist early, even if the first login flow is intentionally simple and uses a hardcoded password.
-- The UI should be shaped and reviewed early using mock data before every backend capability is fully implemented.
-- Job search remains the most important MVP feature after the first auth and layout foundations are in place.
+- The MVP should include most of the intended final workflow, except advanced user management and native mobile apps.
+- The product is for UK developer-job discovery and management.
+- Authentication, persisted job data, job workflow state, profile data, document linkage, and bounded AI support all belong to the MVP.
 - The repository owner remains the primary user and reviewer.
 
 ## Current State Summary
 
 The repo already has:
-- a web app with postcode and keyword inputs, results UI, and tests
+- a web app with public search, login, protected routes, and admin job-management screens
 - a gateway API and downstream identity, job search, and AI APIs
-- database contexts and initial migrations for identity and job search
-- RabbitMQ and event bus infrastructure in place for future async use
-- local development and deployment assets under `services/api` and `infra`
+- current domain models for user accounts and job postings
+- local Docker and test infrastructure
 
-The roadmap should therefore focus on turning that foundation into a stable MVP path rather than restarting the architecture from scratch.
+The roadmap should therefore focus on turning that baseline into the full personal-use workflow rather than re-scaffolding the platform.
 
 ## Recommended Delivery Sequence
 
-### Phase 1: Establish Simple Auth For Early Protected Flows
+### Phase 1: Clarify Product Scope And Data Direction
 
 Goal:
-Create a minimal account and password JWT login flow that is good enough to unlock protected app flows during MVP development.
+Align the PRD, planning docs, and backend data model with the real MVP.
 
 Recommended issue themes:
-- expose a simple login endpoint through the identity API
-- support a hardcoded password path for the initial personal-use login
-- issue and validate JWTs through the existing gateway and identity boundary
-- add the minimum frontend login experience needed to exercise authenticated flows
-- document what is intentionally temporary in the MVP auth design
+- clarify MVP boundaries in the PRD
+- add a data model plan for profile, documents, workflow state, and AI outcomes
+- update roadmap and backlog docs to match the real product intent
 
-Why now:
-- it creates a usable auth foundation without waiting for full identity design
-- it keeps the MVP moving while preserving a path to better auth later
-
-### Phase 2: Shape The Web UI With Mock Data
+### Phase 2: Formalize Roles, Profiles, And Document Metadata
 
 Goal:
-Establish the main application layout and user flow with mock data so the product shape is visible before every backend feature is complete.
+Make `admin` and `test-admin` behavior explicit and persist user profile context needed for later workflows.
 
 Recommended issue themes:
-- define the main authenticated app layout
-- build the initial pages or sections using mock job and profile-oriented data where useful
-- refine navigation, empty states, and loading placeholders
-- keep UI contracts aligned with likely backend response shapes without over-committing
-- identify which mocked areas can later be replaced by real API integration with minimal rewrite
+- formalize backend authorization for `admin` and `test-admin`
+- add user profile persistence
+- add user document metadata for CVs and supporting documents
+- expose profile read/update endpoints and initial frontend screens
 
-Why next:
-- it makes the MVP tangible early
-- it reduces UI uncertainty before deeper backend integration work
-
-### Phase 3: Implement Real Job Search
+### Phase 3: Persisted Job Catalog And Admin Operations
 
 Goal:
-Turn the current search slice into a genuinely useful product capability.
+Turn imported jobs into a durable catalog that can be reviewed and managed.
 
 Recommended issue themes:
-- confirm and document the end-to-end search contract
-- improve search validation rules for postcode and keyword input
-- integrate the first public job source behind the job search service
-- normalize and present real search results clearly in the web app
-- add or refine tests around request handling, search results, and core UX states
+- persist provider-backed import runs and normalized jobs
+- add deduplication rules and provider auditability
+- improve admin CRUD and moderation flows
+- keep provider metadata and raw payload available for review
 
-Why here:
-- job search is the core MVP value
-- the earlier auth and layout work should make this phase easier to integrate and review
-
-### Phase 4: Improve Authentication And Account Management
+### Phase 4: Search, Sorting, And Postcode Distance
 
 Goal:
-Replace the intentionally simple MVP auth path with a more durable identity model.
+Make stored-job search genuinely useful for UK developer-job discovery.
 
 Recommended issue themes:
-- add Gmail Google OAuth sign-in
-- support user registration and account management flows where needed
-- clarify which identity features are truly required for the personal-use product
-- keep JWT issuance and validation centralized while reducing hardcoded assumptions
+- add keyword, sorting, and richer filter support over stored jobs
+- implement postcode-distance filtering
+- harden search validation, loading, empty, and error states
+- keep the search loop clearly constrained to UK developer jobs
 
-Guardrail:
-- do not turn identity into a large platform before the surrounding product flow justifies it
-
-### Phase 5: Expand The AI API
+### Phase 5: Personal Job Workflow
 
 Goal:
-Move the AI API from placeholder shape toward useful but bounded product support.
+Support the real save/apply/reject workflow inside the product.
 
 Recommended issue themes:
-- define the first non-trivial AI endpoints
-- keep AI outputs clearly scoped to supporting the job discovery workflow
-- add simple request and response contracts that can evolve safely
-- avoid background orchestration unless a concrete workflow needs it
+- add saved-job persistence
+- add applied-job and rejected-job state
+- add notes on applications
+- add submitted-document linkage for applications
+- add saved-jobs and applied-jobs views
 
-Guardrail:
-- AI support should improve an existing flow, not become a disconnected feature branch
-
-### Phase 6: Add Advanced Job Search And AI-Assisted Features
+### Phase 6: AI-Assisted Review
 
 Goal:
-Layer in richer search and AI-assisted product behavior after the MVP loop works.
+Add bounded AI support that helps evaluate jobs against stored user context.
 
 Recommended issue themes:
-- richer filtering and result refinement
-- saved or repeatable search behavior if it supports real usage
-- AI-assisted ranking, categorization, or job insight generation
-- resume-aware workflows only when the core job discovery path remains understandable
+- allow admin to select jobs and run AI rating in bulk
+- return 1-5 star fit scores
+- support detailed explanation and CV-improvement guidance
+- persist AI outputs linked to both user and job
 
-Guardrail:
-- advanced features should stay subordinate to a clear, dependable core experience
-
-### Phase 7: Post-MVP Refactor And Architectural Hardening
+### Phase 7: Recruiter-Facing Hardening
 
 Goal:
-Use the completed MVP and real development experience to guide any deeper architectural refinement.
+Make the codebase and product stronger for ongoing use and external review.
 
 Recommended issue themes:
-- identify pain points that the MVP exposed
-- improve testing strategy and TDD discipline where it adds clarity
-- refactor service boundaries, layering, or abstractions only where current code proves the need
-- simplify or harden areas that became difficult to change during MVP delivery
-
-Guardrail:
-- do not refactor into a more complex architecture only because it sounds cleaner on paper
-- use real friction from MVP work as the justification for structural change
+- refine permissions and demo flows for test admin
+- improve operational visibility and error handling
+- strengthen tests around the main vertical slices
+- improve UX polish where it clarifies product quality without broad redesign
 
 ## How To Turn This Roadmap Into Issues
 
@@ -139,17 +110,18 @@ Each issue should:
 - include acceptance criteria that can be validated locally
 
 Good issue examples from this roadmap:
-- add simple JWT login with hardcoded password for MVP access
-- build the authenticated app shell using mock data
-- integrate the first public job provider into the job search service
-- add Gmail OAuth after MVP login flow proves the surrounding UX
+- add user profile persistence for admin and test admin
+- persist uploaded CV metadata and expose profile document endpoints
+- add postcode-distance filtering to stored-job search
+- add saved and applied job workflow state
+- add AI job-fit ratings linked to a user profile
 
 ## Roadmap Maintenance Rule
 
 Update this roadmap when:
 - the recommended sequencing changes materially
 - a major phase has been completed
-- a new constraint changes what should happen next
+- a new product constraint changes what should happen next
 
 Do not update it for every small implementation detail.
 Use `todo.md` for the more changeable working backlog.

--- a/docs/development/todo.md
+++ b/docs/development/todo.md
@@ -1,45 +1,79 @@
 # Development Todo
 
-This file captures quick future task ideas that are not already covered by `roadmap.md`.
-It is meant to stay lightweight and easy to update as new thoughts come up.
+This file captures the prioritized working backlog that is not yet fully represented as completed GitHub issues or roadmap phases.
+It should stay practical, easy to scan, and easy to convert into focused issues.
 
 ## How To Use This File
 
-- Add short ideas here when they are worth remembering but not yet ready to become issues.
-- Move an item out of this file once it becomes part of the roadmap or a real GitHub issue.
-- Keep entries short and practical.
-- Delete stale ideas instead of preserving them indefinitely.
+- Keep tasks grouped by priority.
+- Prefer issue-sized items over vague idea dumping.
+- Remove an item once it becomes an active GitHub issue or completed work.
+- Move sequencing-level changes into `roadmap.md` when they become durable.
 
-## Task Ideas
+## Priority Levels
 
-- Saved searches
-- Search history view
-- Job tracking pipeline
-- Job detail page
-- Resume upload and analysis
-- Cover letter drafting
-- Interview preparation workspace
-- Insights or reporting dashboard
-- Scheduled job collection
-- Storage and deduplication for collected jobs
-- Rate limiting for external job-source usage
-- Better observability around provider failures and slow searches
-- Deployment smoke-check script for the hosted stack
-- Admin-only debug page for service health and configuration visibility
-- Result source comparison view to see which providers return the most useful jobs
-- Notes or personal annotations on saved jobs
-- Export saved jobs or search results
-- Basic notification idea for new matching jobs
+- `P0`
+  Required to deliver the real MVP workflow
+- `P1`
+  Important follow-up work that strengthens the MVP soon after the core slice
+- `P2`
+  Valuable later work that should wait until the MVP loop is stable
 
-## Issues
+## P0: Core MVP Work
 
-- Persist normalized job search results and deduplicate repeated listings.
-- Add saved searches and search history on top of the real search flow.
-- Add scheduled refresh for saved searches or tracked job queries.
-- Add a second provider or fallback provider for better result coverage and resilience.
-- Add clearer provider-failure handling, observability, and rate-limit protection for live search.
+- Clarify product requirements and source-of-truth docs.
+- Formalize backend authorization for `admin` and `test-admin`.
+- Add persisted user profiles for admin and test admin.
+- Add CV and profile-document metadata plus upload flow.
+- Persist imported jobs and deduplicate repeated provider listings.
+- Harden admin CRUD and moderation workflows for stored jobs.
+- Add postcode-distance filtering for UK postcode search.
+- Add richer filters and sorting over stored jobs.
+- Add saved-job persistence.
+- Add applied-job persistence and rejected-job state.
+- Add notes on applied jobs.
+- Add submitted CV and cover-letter linkage for applications.
+- Add separate views for saved jobs and applied jobs.
+- Add AI job-fit ratings from 1 to 5 stars for selected jobs.
+- Add AI detailed explanation and CV-improvement guidance linked to a user.
+
+## P1: Important Near-Term Enhancements
+
+- Add provider-run history and admin visibility for imports.
+- Add postcode lookup/geocoding strategy hardening and caching.
+- Add safer document storage implementation details and retention rules.
+- Add better operational observability around provider imports and AI analysis.
+- Add bulk admin actions for save/apply/reject/moderation flows where they improve review speed.
+- Add more explicit audit history for job moderation and AI analysis runs.
+- Improve recruiter-facing UX polish for admin and test-admin review sessions.
+- Expand functional tests around auth, workflow state, and protected permissions.
+
+## P2: Later Work
+
+- Add a second provider or fallback provider for better result coverage.
+- Add scheduled job collection and refresh automation.
+- Add search history and saved-search automation.
+- Add export flows for saved jobs, applied jobs, or AI outputs.
+- Add notification ideas for newly matching jobs.
+- Add interview-preparation workspace features.
+- Add broader insights or reporting dashboards.
+- Add Google OAuth if it still adds value after the MVP auth flow is stable.
+- Revisit service boundaries if real MVP friction justifies splitting profile, document, or AI workflow concerns.
+
+## Candidate Issue Shapes
+
+- `P0`: Add user profile entity and endpoints in Identity API
+- `P0`: Add user document metadata and local file-upload workflow
+- `P0`: Add postcode-distance filtering to persisted job search
+- `P0`: Add user job state for saved, applied, and rejected jobs
+- `P0`: Add application notes and submitted-document linkage
+- `P0`: Add AI job-fit scoring endpoint and persistence
+- `P1`: Add import-run history and provider diagnostics
+- `P1`: Add test-admin permission coverage across frontend and backend
+- `P2`: Add scheduled refresh for tracked searches
 
 ## Notes
 
-- If an idea becomes important enough to affect sequencing, add it to `roadmap.md` instead.
-- If an idea becomes actionable, turn it into a focused GitHub issue and remove it from this file.
+- Prioritize the real single-user workflow over optional platform expansion.
+- Do not reintroduce placeholder-only features when the backend workflow is not ready.
+- Keep the product constrained to UK developer-job hunting until the MVP is proven.

--- a/docs/frontend-designs.md
+++ b/docs/frontend-designs.md
@@ -33,7 +33,7 @@ Use the files in `docs/frontend-designs/` as the detailed frontend source of tru
 - Do not let one feature reference another feature directly; promote to shared only by deliberate decision.
 
 ## Initial App Scope
-The first frontend slice should support:
+The MVP frontend should support:
 - a landing/search page
 - postcode input
 - keyword input
@@ -42,20 +42,31 @@ The first frontend slice should support:
 - results list
 - empty state
 - error state
-
-Future capabilities such as saved jobs, dashboards, AI recommendations, and document workflows should stay out of the first implementation unless explicitly planned.
+- login and protected routes
+- an authenticated workspace for personal job workflow
+- admin-facing job management flows
+- future saved-job, applied-job, profile, document, and AI-assisted views as part of the real MVP
 
 ## Information Architecture
 Recommended early route shape:
 - `/`
-  - search experience and results
-- future routes
-  - `/jobs/:id`
-  - `/saved`
-  - `/profile`
-  - `/insights`
-
-The first iteration can begin with a single route if that reduces noise.
+  - landing and search entry
+- `/search`
+  - search results
+- `/jobs/:id`
+  - public job detail
+- `/login`
+  - auth entry
+- `/app`
+  - authenticated workspace
+- `/saved`
+  - saved jobs
+- `/applied`
+  - applied jobs
+- `/profile`
+  - user profile and documents
+- `/admin/*`
+  - admin management and AI workflows
 
 ## Suggested Frontend Structure
 ```text
@@ -140,8 +151,8 @@ Use Tailwind for:
 - Ensure loading and error states are screen-reader friendly.
 
 ## Testing Guidance
-- The current UI test files have been intentionally removed and will be reintroduced later.
-- When tests return, prioritize view-level behavior, shared utilities, and important feature logic over low-signal component snapshots.
+- Prioritize view-level behavior, shared utilities, and important feature logic over low-signal component snapshots.
+- Keep auth, search, job workflow, and permission-sensitive UI covered with focused tests.
 
 ## Phased Frontend Implementation
 ### Phase 1
@@ -159,8 +170,8 @@ Use Tailwind for:
 - Add saved state or richer client behavior only if the product requires it
 
 ## Current Recommendation
-Start with one feature slice, one page, one route, and one API client boundary.
-That will keep the first frontend issue sequence fast and understandable while leaving room to grow cleanly.
+Keep the route surface intentional and tied to the real MVP workflow.
+The frontend should stay feature-oriented and reviewable even as the product grows beyond the initial public search slice.
 
 Current repo frontend direction:
 - `docs/frontend-designs/architecture.md` is the concrete architecture contract for future frontend work

--- a/docs/frontend-designs/solution-structure.md
+++ b/docs/frontend-designs/solution-structure.md
@@ -133,12 +133,16 @@ Use only the subfolders that the feature actually needs.
 
 Start with a small route surface:
 - `/`
-- future `/jobs/:id`
-- future `/saved`
-- future `/profile`
-- future `/insights`
+- `/search`
+- `/jobs/:id`
+- `/login`
+- `/app`
+- `/saved`
+- `/applied`
+- `/profile`
+- `/admin/*`
 
-The first real app can begin with one route if that keeps the code cleaner.
+The route surface should stay focused, but the MVP is no longer assumed to be a one-route app.
 
 ## 6. Future Mobile Compatibility Rule
 

--- a/docs/plans.md
+++ b/docs/plans.md
@@ -1,62 +1,68 @@
 # Firefly Signal Plan
 
 ## Planning Scope
-This document captures the initial execution plan for the repository before application scaffolding begins.
-It is intentionally biased toward a practical personal-use MVP, with enough structure to support future AI-assisted development and GitHub issue driven delivery.
+This document captures the current execution plan for Firefly Signal from the repository's real baseline.
+It is intentionally biased toward a practical personal-use MVP that already includes most of the intended final product workflow.
 
-## Working Assumptions
-- The first shipped experience is a web app for UK job discovery.
-- The frontend is client-side only and will talk directly to backend APIs through a Cloudflare-exposed entry point.
+The main features intentionally left beyond the MVP are:
+- advanced user management
+- native mobile applications
+
+## Working Product Assumptions
+- The product is primarily for the repository owner's personal use.
+- The MVP should still behave like a real product that recruiters can review.
+- The MVP should include persisted job data, job workflow management, profile data, document linkage, and bounded AI assistance.
+- The first supported geography is the United Kingdom only.
+- The first supported role category is developer jobs only.
+- The frontend is client-side only and will talk to backend APIs through a Cloudflare-exposed entry point.
 - The backend will run on a Mac mini in Docker behind Cloudflare Tunnel.
-- The initial architecture should preserve room for service separation without forcing distributed-system complexity on day one.
-- The repository owner will review and merge pull requests created with Codex assistance.
 
-## Goals For The First Foundation Phase
-- Clarify the product and technical direction in docs.
-- Establish repo conventions that make future issue-driven work smoother.
-- Prepare for frontend and backend scaffolding without generating unnecessary code too early.
-- Create enough CI and automation structure to keep the repo organized as code arrives.
+## Goals For The Current Planning Phase
+- Keep the product requirements and implementation-facing docs aligned.
+- Deliver the full personal job-search workflow in small, reviewable issues.
+- Keep backend boundaries explicit while avoiding premature service sprawl.
+- Preserve strong code review quality for both maintainability and recruiter visibility.
 
 ## Recommended Delivery Phases
-### Phase 0: Planning And Repo Foundation
-- Finalize product, frontend, backend, and delivery documents.
-- Add detailed extracted backend reference docs under `docs/backend-designs/`.
-- Add deployment assets under `infra/`.
-- Establish repo guardrails in `AGENTS.md`.
-- Add Codex repository skills for planning and implementation workflow.
-- Add root repo hygiene files such as `.gitignore`, `.editorconfig`, and GitHub workflows.
-- Add lightweight linting and formatting conventions for future frontend work.
+### Phase 0: Product And Planning Alignment
+- Clarify the PRD and source-of-truth documentation boundaries.
+- Update roadmap and backlog docs to match the actual MVP.
+- Add a concrete backend data model plan for the MVP workflow.
 
-### Phase 1: Frontend Skeleton
-- Create `apps/web` with React 18, TypeScript, and Vite.
-- Add routing, layout shell, API client boundary, Zustand store setup, MUI theme, and Tailwind integration.
-- Implement the first search page with postcode and keyword inputs, loading state, empty state, and results list placeholders.
-- Add basic linting, testing, and build scripts for the frontend.
-- Use the detailed source of truth in `docs/frontend-designs/` for structure, coding style, state, styling, and testing conventions.
-- Prepare the Cloudflare Pages deployment workflow and app configuration.
+### Phase 1: Identity, Roles, And Profile Foundations
+- Keep the existing auth foundation and formalize role behavior for `admin` and `test-admin`.
+- Add user profile persistence for personal information.
+- Add document metadata and upload handling for CVs and other profile documents.
+- Ensure test admin matches admin frontend visibility while remaining backend read-only.
 
-### Phase 2: Backend Skeleton
-- Create `services/api` as a .NET 10 solution.
-- Use `.slnx` and do not use `.slnf`.
-- Introduce the API gateway, the custom identity API, the job search API, and a lightweight AI API.
-- Add `Directory.Build.props`, `Directory.Build.targets`, and `Directory.Packages.props`.
-- Add shared local Docker development for PostgreSQL, pgweb, RabbitMQ, Redis, and RedisInsight.
-- Establish auth boundary, Snowflake-based long IDs, EF Core migrations and seeding, event bus wiring, configuration loading, health checks, logging, and testing strategy.
-- Keep production Dockerfiles and Mac mini deployment assets under `infra/`, separate from local dev Compose.
+### Phase 2: Persisted Job Catalog And Admin Management
+- Make persisted job storage a first-class MVP capability.
+- Support provider-backed import runs with normalization and deduplication.
+- Support admin CRUD, moderation, and catalog review workflows.
+- Preserve source payload metadata for auditability and future remapping.
 
-### Phase 3: MVP Job Search Flow
-- Implement public source integration for job discovery.
-- Normalize and return search results through the backend.
-- Connect frontend search form to the gateway.
-- Add observability, rate limiting where needed, and persistence decisions only if they add clear value.
+### Phase 3: Search, Filtering, Sorting, And Distance
+- Deliver search over the persisted job catalog.
+- Support keyword, postcode, distance, sorting, and practical filtering.
+- Keep the experience constrained to UK developer jobs.
+- Maintain clear loading, empty, error, and permission states.
 
-### Phase 4: Post-MVP Platform Enhancements
-- Scheduled collection
-- Storage and deduplication
-- Saved searches and tracking
-- Resume-aware scoring
-- AI-assisted workflows
-- Dashboard and analytics
+### Phase 4: Personal Job Workflow
+- Add save-job, applied-job, and rejected-job states.
+- Add views for saved jobs and applied jobs.
+- Support notes on applied jobs.
+- Support attaching submitted CVs and cover letters to applications.
+
+### Phase 5: AI-Assisted Review
+- Let admin select jobs and run AI rating against stored user profile/CV context.
+- Return a 1-5 star rating per job.
+- Support optional detailed explanation and CV improvement guidance.
+- Persist AI outputs and keep them linked to the user they were generated for.
+
+### Phase 6: Recruiter-Visible Hardening
+- Improve code quality, testing coverage, and operational clarity where needed.
+- Refine the UI and admin/test-admin flows for demonstration quality.
+- Keep docs, architecture, and code structure aligned for reviewability.
 
 ## Repository Shape To Grow Into
 ```text
@@ -76,41 +82,39 @@ services/
 ```
 
 ## Delivery Principles
-- Prefer vertical slices over broad platform-first buildout.
-- Keep each GitHub issue small enough to implement, test, and review in one PR.
-- Avoid creating infrastructure pieces that are not yet exercised by a real feature.
+- Prefer vertical slices over abstract platform work.
+- Keep each issue small enough for one focused branch and one reviewable PR.
+- Use real persisted state where the MVP requires it instead of relying on placeholder workflows.
 - Treat docs as active architecture, not passive notes.
-- Preserve optionality for later mobile expansion by keeping API contracts and UI states disciplined.
+- Keep implementation choices easy to explain in a code-review context.
 
-## Proposed Early GitHub Issue Sequence
-1. Initialize repository plumbing
-2. Scaffold frontend app shell
-3. Define frontend design tokens and app layout
-4. Scaffold backend solution and gateway
-5. Add Docker Compose for local dependencies
-6. Define auth strategy and configuration model
-7. Implement job search contract end to end
-8. Add frontend search experience
-9. Integrate first public job source
-10. Add CI quality gates for code paths that now exist
+## Proposed Issue Themes From Here
+1. Clarify PRD and source-of-truth docs
+2. Add user profile and CV/document metadata persistence
+3. Formalize `admin` and `test-admin` authorization behavior
+4. Persist imported jobs and deduplicate provider records
+5. Add admin workflows for job CRUD and moderation
+6. Add postcode distance filtering and sorting over stored jobs
+7. Add saved-job and applied-job persistence
+8. Add application notes and submitted-document linkage
+9. Add AI job rating workflow linked to user profile context
+10. Harden frontend and backend quality around the end-to-end workflow
 
 ## Risks To Manage Early
-- Overcommitting to microservices before the first feature lands
-- Letting frontend and backend contracts drift without a documented API boundary
-- Introducing RabbitMQ or Redis before a concrete use case exists
-- Creating AI features before the underlying product workflow is stable
-- Depending on unstable or restrictive public job data sources without fallback planning
+- Under-modeling the personal workflow and later patching it with ad hoc fields
+- Overcomplicating service boundaries before the workflow is fully implemented
+- Letting document storage and linkage become inconsistent
+- Building AI features without clear user-owned context and auditability
+- Letting product docs lag behind the actual intended MVP
 
 ## Success Criteria For The Planning Phase
-- Product direction is written down and reviewable.
-- Frontend and backend designs are clear enough to guide scaffolding.
-- Repo automation supports disciplined future issue work.
-- The next issue can focus on implementation instead of re-deciding architecture.
-- Frontend architecture, coding style, and delivery guidance are detailed enough to scaffold `apps/web` without re-arguing structure.
+- Product direction is explicit enough to create focused issues without re-deciding scope.
+- MVP boundaries are clear across PRD, plan, backend, and development docs.
+- The backend data model direction is concrete enough to guide implementation.
+- The backlog is prioritized around the real personal-use workflow rather than a smaller demo product.
 
 ## Notes For Future Codex Work
-- Read this file first for sequencing context.
-- Then read `docs/development/overview.md` for the practical coding roadmap and backlog from the current repo baseline.
-- Confirm whether a task belongs to foundation, frontend, backend, or product.
-- Keep issue branches focused on one phase outcome where possible.
-- Record deviations from these assumptions in the PR summary and, when durable, in the relevant design doc.
+- Read the PRD first for scope.
+- Then read this file for sequencing.
+- Then read `docs/development/roadmap.md` and `docs/development/todo.md` for practical issue planning.
+- Update these docs whenever durable product or sequencing decisions change.

--- a/docs/product-requirements-document.md
+++ b/docs/product-requirements-document.md
@@ -4,82 +4,190 @@
 Firefly Signal
 
 ## Product Summary
-Firefly Signal is a personal career intelligence platform.
-Its first milestone is a web application that helps a user discover relevant UK jobs by entering a postcode and keyword, then reviewing clear search results gathered from public sources.
+Firefly Signal is a personal career intelligence workspace for UK software-development job hunting.
+It is being built first for the repository owner, but the product should still feel like a real, reviewable application rather than a throwaway personal script.
 
-## Problem Statement
-Job discovery is fragmented and repetitive.
-The user wants a single place to search by location and intent, review relevant opportunities quickly, and eventually build a richer personal workflow around saved jobs, resume fit, AI assistance, and interview preparation.
+The MVP is intentionally close to the final product.
+It should include the real end-to-end workflow needed to discover jobs, manage a personal job pipeline, store profile material, and use AI to support decisions.
+The main capabilities that are intentionally deferred beyond the MVP are advanced user management and native mobile apps.
+
+## Product Intent
+- Help one user find relevant UK developer jobs efficiently.
+- Keep the workflow persisted, reviewable, and practical for daily use.
+- Build a codebase and web product that recruiters can inspect as evidence of product thinking, engineering quality, and maintainable structure.
+- Preserve a path to broader future usage without forcing multi-tenant complexity into the MVP.
 
 ## Primary User
 - Repository owner
 - Personal-use first
-- Technically capable and comfortable evolving the product over time
+- Looking specifically for UK developer jobs
+- Comfortable with a web-first workflow
 
-## Initial Use Case
-1. User opens the web app.
+## Supported Geography And Job Focus
+- Geography: United Kingdom only for the MVP
+- Role focus: software-development jobs only for the MVP
+- Location filtering must support distance-from-postcode search
+
+## Supported Roles
+### Admin
+- Full frontend access
+- Full backend write access
+- Own profile, CV, and personal information
+- Can import, manage, analyze, save, apply, and review jobs
+
+### Test Admin
+- Same frontend navigation and visible product surface as admin
+- Read-only backend permissions for protected write operations
+- Own separate profile, CV, and personal information
+- Intended for demo and review access without permitting destructive or data-changing backend actions
+
+## Documentation Source Of Truth
+- `docs/product-requirements-document.md`
+  Product scope, MVP definition, user workflows, and requirement boundaries
+- `docs/plans.md`
+  Delivery sequencing and phase-level planning
+- `docs/frontend-designs.md`
+  Frontend implementation direction and UI architecture
+- `docs/backend-designs.md`
+  Backend service direction, persistence boundaries, and integration design
+- `docs/development/roadmap.md`
+  Practical implementation order from the current repo baseline
+- `docs/development/todo.md`
+  Prioritized working backlog and candidate future issues
+
+If there is a conflict, product scope should be resolved here first and then propagated to the implementation-facing docs.
+
+## Product Vision
+The final product should let the user:
+- load jobs from external providers through public APIs or controlled scraping
+- persist and manage a job catalog locally
+- search, filter, and sort jobs effectively
+- save jobs and move them through a personal application workflow
+- maintain personal profile and CV information in the product
+- attach submitted documents and notes to applied jobs
+- use AI assistance to rate and explain job fit based on the user's stored profile material
+
+The MVP should already include these core capabilities in a practical single-user form.
+
+## MVP User Journeys
+### 1. Load And Maintain Job Catalog
+1. Admin triggers a job import from one or more providers.
+2. System fetches job listings from public APIs or approved scraping flows.
+3. System normalizes and stores jobs in the local database.
+4. Admin can review imported jobs, hide bad records, edit records when needed, or delete records.
+
+### 2. Search And Review Jobs
+1. User enters a keyword.
 2. User enters a UK postcode.
-3. User enters a job keyword.
-4. User submits the search.
-5. System retrieves relevant job opportunities from public sources.
-6. System displays clear, useful results.
+3. User optionally applies filters and sorting.
+4. User filters by distance from the postcode.
+5. System returns stored UK developer jobs that match the search and filter criteria.
+6. User opens job details and can decide whether to save, apply, reject, or ignore the listing.
+
+### 3. Manage Personal Job Workflow
+1. User saves a job for later review.
+2. User marks a job as applied.
+3. User attaches the CV and cover letter used for that application.
+4. User writes notes against the application.
+5. User can later mark the application as rejected.
+6. User can separately view saved jobs and applied jobs.
+
+### 4. Manage Profile Material
+1. User stores personal profile information in the product.
+2. User uploads CVs and supporting profile documents.
+3. System persists profile data and document metadata so later workflows can use them.
+4. Admin and test admin each have their own separate stored profile data.
+
+### 5. Run AI Assistance
+1. Admin selects one or more jobs in an admin workflow.
+2. Admin asks AI to analyze those jobs against the selected user's CV and profile data.
+3. System sends the relevant job and user context to the AI service.
+4. AI returns a suggested rating from 1 to 5 stars for each job.
+5. Admin can also request detailed explanation and CV improvement guidance.
+6. AI notes and ratings are linked to the user they were generated for.
 
 ## MVP Goals
-- Provide useful job search results for UK-based discovery.
-- Make search quick and repeatable.
-- Keep the product lightweight and easy to maintain.
-- Establish a foundation for future persistence and AI assistance.
+- Provide a practical personal-use system for UK developer job discovery and tracking.
+- Persist job data locally instead of depending only on transient search responses.
+- Support a full personal workflow from job ingestion through application tracking.
+- Support profile and document storage needed for real applications.
+- Support AI-assisted rating and explanation as a bounded workflow tied to stored user context.
+- Keep the codebase clean and reviewable for external code inspection.
 
 ## MVP Non-Goals
 - Native mobile applications
-- Enterprise or multi-tenant account management
-- Complex social or collaboration features
-- Broad dashboarding before core search works well
-- Heavy AI features before the core data flow is valuable
+- Advanced multi-user account management
+- Complex tenant, team, or organization features
+- Public self-serve sign-up flows for arbitrary users
+- Generalized recruiting or ATS platform workflows
+- Broad non-UK or non-developer job support
 
 ## Functional Requirements
-### Search Input
-- User can enter a UK postcode.
-- User can enter a job keyword or phrase.
-- System validates obviously invalid input.
+### Authentication And Access
+- System supports at least `admin` and `test-admin` roles.
+- Admin can perform backend write operations.
+- Test admin can access the same frontend areas but is blocked from backend mutations.
+- Protected routes must reflect backend authorization decisions clearly.
 
-### Search Execution
-- System queries one or more public job data sources.
-- System returns results relevant to the requested keyword and location intent.
-- System handles slow or failed provider responses gracefully.
+### Job Ingestion And Storage
+- System can load jobs from external providers through public APIs and, if needed later, controlled scraping.
+- Imported jobs are stored in PostgreSQL.
+- System keeps enough provider metadata to re-check, audit, and debug imported records.
+- System supports admin CRUD operations for stored jobs.
+- System supports hiding low-quality or unwanted jobs from normal search results.
 
-### Search Results
-- System displays a list of jobs with enough information to assess relevance quickly.
-- Each result should include, where available:
-  - job title
-  - company or employer
-  - location
-  - source
-  - summary snippet
-  - link or path to original listing
-  - freshness or posted date
+### Search And Discovery
+- User can search by keyword.
+- User can search by UK postcode.
+- User can filter by distance from the entered postcode.
+- User can apply additional filters and sorting against stored jobs.
+- Search results must stay constrained to UK developer jobs for the MVP.
+- Search results must provide enough detail to judge relevance quickly.
 
-### Reliability
-- System provides a clear error state when search fails.
-- System provides a clear empty state when no results are found.
-- System should be simple to operate and debug by one maintainer.
+### Job Detail
+- Job detail view must show normalized job information and a path to the original listing.
+- Job detail must support save, apply, reject, and AI-review-oriented workflows once those features exist.
 
-## Future Requirements
-- Saved jobs
-- Search history
-- Job tracking pipeline
-- Resume upload and analysis
-- Personalized ranking and recommendation
-- Cover letter drafting
-- Interview preparation
-- Insights and reporting
+### Personal Job Workflow
+- User can save jobs.
+- User can mark jobs as applied.
+- User can mark jobs as rejected.
+- User can view saved jobs separately from applied jobs.
+- User can add notes to applied jobs.
+- User can attach submitted CVs and cover letters to applied jobs.
+
+### Profile And Document Management
+- User can store personal profile information needed for AI-assisted fit review.
+- User can upload CVs.
+- User can upload other personal supporting documents where needed.
+- User profile data and documents are stored per user.
+
+### AI Assistance
+- Admin can select jobs and run AI rating against a chosen user's stored profile context.
+- AI must return a 1-5 star rating per job.
+- Admin can request a more detailed explanation for selected jobs.
+- AI can return CV improvement suggestions related to a job.
+- AI notes and ratings are stored with user linkage so they remain attributable and reviewable later.
+
+### Reliability And Reviewability
+- Search must expose clear loading, empty, and error states.
+- Protected workflows must expose permission failures clearly.
+- The codebase must remain structured, understandable, and reviewable in small increments.
+- Product behavior must avoid placeholder-only features that are not supported by real backend state.
+
+## Core Data Expectations
+- Jobs are persisted and manageable.
+- Saved and applied states are persisted per user.
+- Notes are persisted per application or job workflow record.
+- Uploaded document metadata is persisted in the database.
+- AI outputs are persisted and linked to both user and job context.
 
 ## Quality Attributes
-- Fast perceived response time
-- Clear UX with low friction
-- Maintainable architecture
-- Good observability for debugging
-- Secure authentication model for future protected workflows
+- Clear and fast search workflow
+- Low-friction personal job management
+- Maintainable architecture for a single primary maintainer
+- Good auditability of imported jobs and AI outputs
+- Strong demo value for recruiter review of both UX and code
 
 ## Constraints
 - Frontend hosted on Cloudflare
@@ -88,23 +196,29 @@ The user wants a single place to search by location and intent, review relevant 
 - Frontend is client-side rendered
 - Backend stack is .NET 10, PostgreSQL, EF Core, RabbitMQ, and selective Redis
 - Do not use .NET Aspire
+- MVP is single-user oriented in practice, but should not be coded as an unstructured one-off
 
-## Success Metrics For Early Releases
-- User can complete a search without confusion.
-- Returned results are relevant enough to justify repeated use.
-- The product remains easy to change issue by issue.
-- The first end-to-end slice can be deployed and tested without heavy manual work.
+## Success Criteria For Early Releases
+- User can import and manage UK developer jobs without leaving the product for core workflow steps.
+- User can search persisted jobs by keyword and postcode distance without confusion.
+- User can save, apply, reject, annotate, and review jobs in one coherent system.
+- User can maintain profile material and use it in AI analysis flows.
+- Admin and test admin flows are both demonstrable and clearly permissioned.
+- The codebase remains clean enough to support recruiter review and future issue-by-issue delivery.
 
 ## Product Risks
-- Public job source quality or access may vary.
-- Over-building infrastructure may slow actual user value.
-- Search relevance may depend heavily on source quality and normalization choices.
+- Public job source quality, coverage, terms, and rate limits may vary.
+- Postcode-distance filtering depends on reliable geocoding or postcode reference data.
+- File/document storage strategy can become messy if not bounded early.
+- AI output quality may vary and must be presented as assistance rather than ground truth.
+- Over-fragmenting services too early could slow delivery of the actual MVP workflow.
 
-## Open Questions
-- Which job sources should be prioritized first?
-- How much search history or persistence is valuable in the first release?
-- Should auth be required for the first MVP, or introduced immediately after the search loop works?
+## Deliberately Deferred Decisions
+- Exact provider order after the first live provider is integrated
+- Exact long-term storage backend for document binaries beyond the MVP local-first path
+- Whether scraping becomes necessary for provider coverage after public API evaluation
+- Whether future non-admin roles beyond `test-admin` are justified
 
 ## Current Recommendation
-Build the smallest useful search loop first.
-Once search quality and usability are proven, add persistence, personalization, and AI-assisted workflows incrementally.
+Build the MVP as a real single-user product, not as a stripped-down demo.
+Keep the scope broad enough to support the actual personal job workflow, while still avoiding advanced user-management and mobile-platform work.


### PR DESCRIPTION
Closes #35

## Summary
- rewrite the PRD around the real single-user MVP rather than a smaller search-only demo
- align planning, backend, frontend, and development docs around persisted workflow state, admin/test-admin roles, and bounded AI support
- add a backend data model plan and rework the todo list into a prioritized backlog

## Validation
- documentation consistency pass across product, plans, frontend, backend, and development docs

## Assumptions
- detailed field-level and implementation-level requirement debates will continue through focused follow-up issues
