### PR TITLE
feat(api): add MVP workflow schema foundations (#36)

### DIFF
--- a/services/api/src/Firefly.Signal.Identity.Api/Domain/UserAccount.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Domain/UserAccount.cs
@@ -50,5 +50,6 @@ public sealed class UserAccount : AuditableEntity, IAggregateRoot
 public static class Roles
 {
     public const string Admin = "admin";
+    public const string TestAdmin = "test-admin";
     public const string User = "user";
 }

--- a/services/api/src/Firefly.Signal.Identity.Api/Domain/UserDocument.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Domain/UserDocument.cs
@@ -1,0 +1,88 @@
+using Firefly.Signal.SharedKernel.Domain;
+
+namespace Firefly.Signal.Identity.Domain;
+
+/// <summary>
+/// Metadata for a user-owned document such as a CV or cover letter.
+/// </summary>
+public sealed class UserDocument : AuditableEntity, IAggregateRoot
+{
+    private UserDocument()
+    {
+    }
+
+    public long UserAccountId { get; private set; }
+    public UserDocumentType DocumentType { get; private set; }
+    public string DisplayName { get; private set; } = string.Empty;
+    public string OriginalFileName { get; private set; } = string.Empty;
+    /// <summary>
+    /// Storage key or relative file path used to resolve the physical document outside the relational row.
+    /// </summary>
+    public string StorageKey { get; private set; } = string.Empty;
+    public string ContentType { get; private set; } = string.Empty;
+    public long FileSizeBytes { get; private set; }
+    /// <summary>
+    /// Content checksum used to support duplicate detection and safer file management.
+    /// </summary>
+    public string ChecksumSha256 { get; private set; } = string.Empty;
+    /// <summary>
+    /// Indicates whether this document is the user's default choice for its document type.
+    /// </summary>
+    public bool IsDefault { get; private set; }
+    public DateTime UploadedAtUtc { get; private set; }
+
+    public static UserDocument Create(
+        long userAccountId,
+        UserDocumentType documentType,
+        string displayName,
+        string originalFileName,
+        string storageKey,
+        string contentType,
+        long fileSizeBytes,
+        string checksumSha256,
+        bool isDefault)
+    {
+        return new UserDocument
+        {
+            UserAccountId = userAccountId,
+            DocumentType = documentType,
+            DisplayName = displayName.Trim(),
+            OriginalFileName = originalFileName.Trim(),
+            StorageKey = storageKey.Trim(),
+            ContentType = contentType.Trim(),
+            FileSizeBytes = fileSizeBytes,
+            ChecksumSha256 = checksumSha256.Trim(),
+            IsDefault = isDefault,
+            UploadedAtUtc = DateTime.UtcNow
+        };
+    }
+
+    public void UpdateMetadata(
+        string displayName,
+        string originalFileName,
+        string storageKey,
+        string contentType,
+        long fileSizeBytes,
+        string checksumSha256)
+    {
+        DisplayName = displayName.Trim();
+        OriginalFileName = originalFileName.Trim();
+        StorageKey = storageKey.Trim();
+        ContentType = contentType.Trim();
+        FileSizeBytes = fileSizeBytes;
+        ChecksumSha256 = checksumSha256.Trim();
+        Touch();
+    }
+
+    public void MarkDefault()
+    {
+        IsDefault = true;
+        Touch();
+    }
+
+    public void ClearDefault()
+    {
+        IsDefault = false;
+        Touch();
+    }
+}

--- a/services/api/src/Firefly.Signal.Identity.Api/Domain/UserDocumentType.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Domain/UserDocumentType.cs
@@ -1,0 +1,9 @@
+namespace Firefly.Signal.Identity.Domain;
+
+public enum UserDocumentType
+{
+    Cv = 1,
+    CoverLetter = 2,
+    ProfileSupporting = 3,
+    Other = 4
+}

--- a/services/api/src/Firefly.Signal.Identity.Api/Domain/UserProfile.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Domain/UserProfile.cs
@@ -1,0 +1,101 @@
+using Firefly.Signal.SharedKernel.Domain;
+
+namespace Firefly.Signal.Identity.Domain;
+
+/// <summary>
+/// Stores the user's profile context used by job review and AI-assisted workflows.
+/// </summary>
+public sealed class UserProfile : AuditableEntity, IAggregateRoot
+{
+    private UserProfile()
+    {
+    }
+
+    /// <summary>
+    /// Owning account for this profile record.
+    /// </summary>
+    public long UserAccountId { get; private set; }
+    public string? FullName { get; private set; }
+    public string? PreferredTitle { get; private set; }
+    /// <summary>
+    /// Primary UK postcode used as the default location anchor for search and distance calculations.
+    /// </summary>
+    public string? PrimaryLocationPostcode { get; private set; }
+    public string? LinkedInUrl { get; private set; }
+    public string? GithubUrl { get; private set; }
+    public string? PortfolioUrl { get; private set; }
+    public string? Summary { get; private set; }
+    /// <summary>
+    /// Free-form skills snapshot kept flexible for the MVP.
+    /// </summary>
+    public string? SkillsText { get; private set; }
+    /// <summary>
+    /// Free-form experience summary kept flexible for the MVP.
+    /// </summary>
+    public string? ExperienceText { get; private set; }
+    /// <summary>
+    /// JSON-backed preference storage for light MVP customization without early over-normalization.
+    /// </summary>
+    public string PreferencesJson { get; private set; } = "{}";
+
+    public static UserProfile Create(
+        long userAccountId,
+        string? fullName,
+        string? preferredTitle,
+        string? primaryLocationPostcode,
+        string? linkedInUrl,
+        string? githubUrl,
+        string? portfolioUrl,
+        string? summary,
+        string? skillsText,
+        string? experienceText,
+        string? preferencesJson)
+    {
+        return new UserProfile
+        {
+            UserAccountId = userAccountId,
+            FullName = Normalize(fullName),
+            PreferredTitle = Normalize(preferredTitle),
+            PrimaryLocationPostcode = NormalizePostcode(primaryLocationPostcode),
+            LinkedInUrl = Normalize(linkedInUrl),
+            GithubUrl = Normalize(githubUrl),
+            PortfolioUrl = Normalize(portfolioUrl),
+            Summary = Normalize(summary),
+            SkillsText = Normalize(skillsText),
+            ExperienceText = Normalize(experienceText),
+            PreferencesJson = NormalizeJson(preferencesJson)
+        };
+    }
+
+    public void Update(
+        string? fullName,
+        string? preferredTitle,
+        string? primaryLocationPostcode,
+        string? linkedInUrl,
+        string? githubUrl,
+        string? portfolioUrl,
+        string? summary,
+        string? skillsText,
+        string? experienceText,
+        string? preferencesJson)
+    {
+        FullName = Normalize(fullName);
+        PreferredTitle = Normalize(preferredTitle);
+        PrimaryLocationPostcode = NormalizePostcode(primaryLocationPostcode);
+        LinkedInUrl = Normalize(linkedInUrl);
+        GithubUrl = Normalize(githubUrl);
+        PortfolioUrl = Normalize(portfolioUrl);
+        Summary = Normalize(summary);
+        SkillsText = Normalize(skillsText);
+        ExperienceText = Normalize(experienceText);
+        PreferencesJson = NormalizeJson(preferencesJson);
+        Touch();
+    }
+
+    private static string? Normalize(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? NormalizePostcode(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim().ToUpperInvariant();
+
+    private static string NormalizeJson(string? value) => string.IsNullOrWhiteSpace(value) ? "{}" : value.Trim();
+}

--- a/services/api/src/Firefly.Signal.Identity.Api/Infrastructure/Persistence/IdentityDbContext.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Infrastructure/Persistence/IdentityDbContext.cs
@@ -9,6 +9,8 @@ public sealed class IdentityDbContext(DbContextOptions<IdentityDbContext> option
     public const string SchemaName = "identity";
 
     public DbSet<UserAccount> Users => Set<UserAccount>();
+    public DbSet<UserProfile> UserProfiles => Set<UserProfile>();
+    public DbSet<UserDocument> UserDocuments => Set<UserDocument>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -28,6 +30,56 @@ public sealed class IdentityDbContext(DbContextOptions<IdentityDbContext> option
             entity.Property(x => x.UpdatedAtUtc).IsRequired();
             entity.HasIndex(x => x.UserAccountName).IsUnique();
             entity.HasIndex(x => x.Email).IsUnique();
+        });
+
+        modelBuilder.Entity<UserProfile>(entity =>
+        {
+            entity.ToTable("user_profiles");
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Id).ValueGeneratedNever();
+            entity.Property(x => x.UserAccountId).IsRequired();
+            entity.Property(x => x.FullName).HasMaxLength(200);
+            entity.Property(x => x.PreferredTitle).HasMaxLength(160);
+            entity.Property(x => x.PrimaryLocationPostcode).HasMaxLength(16);
+            entity.Property(x => x.LinkedInUrl).HasMaxLength(512);
+            entity.Property(x => x.GithubUrl).HasMaxLength(512);
+            entity.Property(x => x.PortfolioUrl).HasMaxLength(512);
+            entity.Property(x => x.Summary).HasMaxLength(4000);
+            entity.Property(x => x.SkillsText).HasMaxLength(8000);
+            entity.Property(x => x.ExperienceText).HasMaxLength(8000);
+            entity.Property(x => x.PreferencesJson).HasColumnType("jsonb").IsRequired();
+            entity.Property(x => x.CreatedAtUtc).IsRequired();
+            entity.Property(x => x.UpdatedAtUtc).IsRequired();
+            entity.HasIndex(x => x.UserAccountId).IsUnique();
+            entity.HasOne<UserAccount>()
+                .WithMany()
+                .HasForeignKey(x => x.UserAccountId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<UserDocument>(entity =>
+        {
+            entity.ToTable("user_documents");
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Id).ValueGeneratedNever();
+            entity.Property(x => x.UserAccountId).IsRequired();
+            entity.Property(x => x.DocumentType).HasConversion<string>().HasMaxLength(32).IsRequired();
+            entity.Property(x => x.DisplayName).HasMaxLength(200).IsRequired();
+            entity.Property(x => x.OriginalFileName).HasMaxLength(260).IsRequired();
+            entity.Property(x => x.StorageKey).HasMaxLength(512).IsRequired();
+            entity.Property(x => x.ContentType).HasMaxLength(256).IsRequired();
+            entity.Property(x => x.FileSizeBytes).IsRequired();
+            entity.Property(x => x.ChecksumSha256).HasMaxLength(64).IsRequired();
+            entity.Property(x => x.IsDefault).IsRequired();
+            entity.Property(x => x.UploadedAtUtc).IsRequired();
+            entity.Property(x => x.CreatedAtUtc).IsRequired();
+            entity.Property(x => x.UpdatedAtUtc).IsRequired();
+            entity.HasIndex(x => x.UserAccountId);
+            entity.HasIndex(x => new { x.UserAccountId, x.DocumentType, x.IsDefault });
+            entity.HasOne<UserAccount>()
+                .WithMany()
+                .HasForeignKey(x => x.UserAccountId)
+                .OnDelete(DeleteBehavior.Cascade);
         });
 
         modelBuilder.ApplySoftDeleteQueryFilters();

--- a/services/api/src/Firefly.Signal.Identity.Api/Infrastructure/Persistence/IdentityDbContextSeed.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Infrastructure/Persistence/IdentityDbContextSeed.cs
@@ -14,10 +14,10 @@ public sealed class IdentityDbContextSeed(IPasswordHasher<UserAccount> passwordH
             var admin = UserAccount.Create("admin", string.Empty, "admin@firefly.local", "Firefly Admin", Roles.Admin);
             admin.ChangePassword(passwordHasher.HashPassword(admin, "Admin123!"));
 
-            var analyst = UserAccount.Create("analyst", string.Empty, "analyst@firefly.local", "Sample Analyst", Roles.User);
-            analyst.ChangePassword(passwordHasher.HashPassword(analyst, "Analyst123!"));
+            var testAdmin = UserAccount.Create("testadmin", string.Empty, "testadmin@firefly.local", "Firefly Test Admin", Roles.TestAdmin);
+            testAdmin.ChangePassword(passwordHasher.HashPassword(testAdmin, "TestAdmin123!"));
 
-            context.Users.AddRange(admin, analyst);
+            context.Users.AddRange(admin, testAdmin);
             await context.SaveChangesAsync();
         }
     }

--- a/services/api/src/Firefly.Signal.Identity.Api/Infrastructure/Persistence/Migrations/20260411124925_AddUserProfileAndDocuments.Designer.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Infrastructure/Persistence/Migrations/20260411124925_AddUserProfileAndDocuments.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Firefly.Signal.Identity.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Firefly.Signal.Identity.Api.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(IdentityDbContext))]
-    partial class IdentityDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411124925_AddUserProfileAndDocuments")]
+    partial class AddUserProfileAndDocuments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/services/api/src/Firefly.Signal.Identity.Api/Infrastructure/Persistence/Migrations/20260411124925_AddUserProfileAndDocuments.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Infrastructure/Persistence/Migrations/20260411124925_AddUserProfileAndDocuments.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Firefly.Signal.Identity.Api.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserProfileAndDocuments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "user_documents",
+                schema: "identity",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    UserAccountId = table.Column<long>(type: "bigint", nullable: false),
+                    DocumentType = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    OriginalFileName = table.Column<string>(type: "character varying(260)", maxLength: 260, nullable: false),
+                    StorageKey = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    ContentType = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    FileSizeBytes = table.Column<long>(type: "bigint", nullable: false),
+                    ChecksumSha256 = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    IsDefault = table.Column<bool>(type: "boolean", nullable: false),
+                    UploadedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_user_documents", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_user_documents_users_UserAccountId",
+                        column: x => x.UserAccountId,
+                        principalSchema: "identity",
+                        principalTable: "users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "user_profiles",
+                schema: "identity",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    UserAccountId = table.Column<long>(type: "bigint", nullable: false),
+                    FullName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    PreferredTitle = table.Column<string>(type: "character varying(160)", maxLength: 160, nullable: true),
+                    PrimaryLocationPostcode = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: true),
+                    LinkedInUrl = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    GithubUrl = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    PortfolioUrl = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    Summary = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
+                    SkillsText = table.Column<string>(type: "character varying(8000)", maxLength: 8000, nullable: true),
+                    ExperienceText = table.Column<string>(type: "character varying(8000)", maxLength: 8000, nullable: true),
+                    PreferencesJson = table.Column<string>(type: "jsonb", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_user_profiles", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_user_profiles_users_UserAccountId",
+                        column: x => x.UserAccountId,
+                        principalSchema: "identity",
+                        principalTable: "users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_documents_UserAccountId",
+                schema: "identity",
+                table: "user_documents",
+                column: "UserAccountId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_documents_UserAccountId_DocumentType_IsDefault",
+                schema: "identity",
+                table: "user_documents",
+                columns: new[] { "UserAccountId", "DocumentType", "IsDefault" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_profiles_UserAccountId",
+                schema: "identity",
+                table: "user_profiles",
+                column: "UserAccountId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "user_documents",
+                schema: "identity");
+
+            migrationBuilder.DropTable(
+                name: "user_profiles",
+                schema: "identity");
+        }
+    }
+}

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Domain/AiAnalysisRun.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Domain/AiAnalysisRun.cs
@@ -1,0 +1,60 @@
+using Firefly.Signal.SharedKernel.Domain;
+
+namespace Firefly.Signal.JobSearch.Domain;
+
+/// <summary>
+/// Tracks one admin-triggered AI analysis request over a set of jobs for a target user.
+/// </summary>
+public sealed class AiAnalysisRun : AuditableEntity, IAggregateRoot
+{
+    private AiAnalysisRun()
+    {
+    }
+
+    public long RequestedByUserAccountId { get; private set; }
+    /// <summary>
+    /// User whose stored profile and documents are used as the AI comparison context.
+    /// </summary>
+    public long TargetUserAccountId { get; private set; }
+    public AiAnalysisRunMode Mode { get; private set; }
+    public AiAnalysisRunStatus Status { get; private set; }
+    public int JobCount { get; private set; }
+    public DateTime StartedAtUtc { get; private set; }
+    public DateTime? CompletedAtUtc { get; private set; }
+    public string? FailureSummary { get; private set; }
+
+    public static AiAnalysisRun Start(
+        long requestedByUserAccountId,
+        long targetUserAccountId,
+        AiAnalysisRunMode mode,
+        int jobCount)
+    {
+        return new AiAnalysisRun
+        {
+            RequestedByUserAccountId = requestedByUserAccountId,
+            TargetUserAccountId = targetUserAccountId,
+            Mode = mode,
+            Status = AiAnalysisRunStatus.Running,
+            JobCount = jobCount,
+            StartedAtUtc = DateTime.UtcNow
+        };
+    }
+
+    public void Complete(bool partial = false)
+    {
+        Status = partial ? AiAnalysisRunStatus.PartiallyCompleted : AiAnalysisRunStatus.Completed;
+        CompletedAtUtc = DateTime.UtcNow;
+        FailureSummary = null;
+        Touch();
+    }
+
+    public void Fail(string? failureSummary)
+    {
+        Status = AiAnalysisRunStatus.Failed;
+        CompletedAtUtc = DateTime.UtcNow;
+        FailureSummary = Normalize(failureSummary);
+        Touch();
+    }
+
+    private static string? Normalize(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Domain/AiAnalysisRunMode.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Domain/AiAnalysisRunMode.cs
@@ -1,0 +1,8 @@
+namespace Firefly.Signal.JobSearch.Domain;
+
+public enum AiAnalysisRunMode
+{
+    Rating = 1,
+    Detailed = 2,
+    CvImprovement = 3
+}

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Domain/AiAnalysisRunStatus.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Domain/AiAnalysisRunStatus.cs
@@ -1,0 +1,10 @@
+namespace Firefly.Signal.JobSearch.Domain;
+
+public enum AiAnalysisRunStatus
+{
+    Pending = 1,
+    Running = 2,
+    Completed = 3,
+    PartiallyCompleted = 4,
+    Failed = 5
+}

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Domain/ApplicationDocumentLink.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Domain/ApplicationDocumentLink.cs
@@ -1,0 +1,36 @@
+using Firefly.Signal.SharedKernel.Domain;
+
+namespace Firefly.Signal.JobSearch.Domain;
+
+/// <summary>
+/// Links a user-owned document to an application with explicit purpose metadata.
+/// </summary>
+public sealed class ApplicationDocumentLink : AuditableEntity
+{
+    private ApplicationDocumentLink()
+    {
+    }
+
+    public long JobApplicationId { get; private set; }
+    public long UserDocumentId { get; private set; }
+    public ApplicationDocumentLinkType LinkType { get; private set; }
+
+    public static ApplicationDocumentLink Create(
+        long jobApplicationId,
+        long userDocumentId,
+        ApplicationDocumentLinkType linkType)
+    {
+        return new ApplicationDocumentLink
+        {
+            JobApplicationId = jobApplicationId,
+            UserDocumentId = userDocumentId,
+            LinkType = linkType
+        };
+    }
+
+    public void ChangeLinkType(ApplicationDocumentLinkType linkType)
+    {
+        LinkType = linkType;
+        Touch();
+    }
+}

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Domain/ApplicationDocumentLinkType.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Domain/ApplicationDocumentLinkType.cs
@@ -1,0 +1,8 @@
+namespace Firefly.Signal.JobSearch.Domain;
+
+public enum ApplicationDocumentLinkType
+{
+    SubmittedCv = 1,
+    SubmittedCoverLetter = 2,
+    SupportingDocument = 3
+}

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Domain/ApplicationNote.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Domain/ApplicationNote.cs
@@ -1,0 +1,33 @@
+using Firefly.Signal.SharedKernel.Domain;
+
+namespace Firefly.Signal.JobSearch.Domain;
+
+/// <summary>
+/// Free-form note attached to a specific application record.
+/// </summary>
+public sealed class ApplicationNote : AuditableEntity
+{
+    private ApplicationNote()
+    {
+    }
+
+    public long JobApplicationId { get; private set; }
+    public long UserAccountId { get; private set; }
+    public string Body { get; private set; } = string.Empty;
+
+    public static ApplicationNote Create(long jobApplicationId, long userAccountId, string body)
+    {
+        return new ApplicationNote
+        {
+            JobApplicationId = jobApplicationId,
+            UserAccountId = userAccountId,
+            Body = body.Trim()
+        };
+    }
+
+    public void UpdateBody(string body)
+    {
+        Body = body.Trim();
+        Touch();
+    }
+}

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Domain/JobApplication.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Domain/JobApplication.cs
@@ -1,0 +1,63 @@
+using Firefly.Signal.SharedKernel.Domain;
+
+namespace Firefly.Signal.JobSearch.Domain;
+
+/// <summary>
+/// Captures the persisted user-specific application record for a job.
+/// </summary>
+public sealed class JobApplication : AuditableEntity, IAggregateRoot
+{
+    private JobApplication()
+    {
+    }
+
+    public long UserAccountId { get; private set; }
+    public long JobPostingId { get; private set; }
+    public DateTime AppliedAtUtc { get; private set; }
+    public JobApplicationStatus Status { get; private set; }
+    /// <summary>
+    /// User document selected as the CV actually submitted for this application.
+    /// </summary>
+    public long? SubmittedCvDocumentId { get; private set; }
+    /// <summary>
+    /// User document selected as the cover letter actually submitted for this application.
+    /// </summary>
+    public long? SubmittedCoverLetterDocumentId { get; private set; }
+    public DateTime? RejectionAtUtc { get; private set; }
+    public string? RejectionReason { get; private set; }
+
+    public static JobApplication Create(
+        long userAccountId,
+        long jobPostingId,
+        long? submittedCvDocumentId,
+        long? submittedCoverLetterDocumentId,
+        DateTime? appliedAtUtc = null)
+    {
+        return new JobApplication
+        {
+            UserAccountId = userAccountId,
+            JobPostingId = jobPostingId,
+            AppliedAtUtc = appliedAtUtc ?? DateTime.UtcNow,
+            Status = JobApplicationStatus.Applied,
+            SubmittedCvDocumentId = submittedCvDocumentId,
+            SubmittedCoverLetterDocumentId = submittedCoverLetterDocumentId
+        };
+    }
+
+    public void UpdateSubmittedDocuments(long? submittedCvDocumentId, long? submittedCoverLetterDocumentId)
+    {
+        SubmittedCvDocumentId = submittedCvDocumentId;
+        SubmittedCoverLetterDocumentId = submittedCoverLetterDocumentId;
+        Touch();
+    }
+
+    public void MarkRejected(string? rejectionReason, DateTime? rejectedAtUtc = null)
+    {
+        Status = JobApplicationStatus.Rejected;
+        RejectionReason = Normalize(rejectionReason);
+        RejectionAtUtc = rejectedAtUtc ?? DateTime.UtcNow;
+        Touch();
+    }
+
+    private static string? Normalize(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Domain/JobApplicationStatus.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Domain/JobApplicationStatus.cs
@@ -1,0 +1,7 @@
+namespace Firefly.Signal.JobSearch.Domain;
+
+public enum JobApplicationStatus
+{
+    Applied = 1,
+    Rejected = 2
+}

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Domain/PostcodeLookup.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Domain/PostcodeLookup.cs
@@ -1,0 +1,43 @@
+using Firefly.Signal.SharedKernel.Domain;
+
+namespace Firefly.Signal.JobSearch.Domain;
+
+/// <summary>
+/// Cached or imported postcode reference data used for distance-based filtering.
+/// </summary>
+public sealed class PostcodeLookup : AuditableEntity, IAggregateRoot
+{
+    private PostcodeLookup()
+    {
+    }
+
+    public string Postcode { get; private set; } = string.Empty;
+    public decimal Latitude { get; private set; }
+    public decimal Longitude { get; private set; }
+    /// <summary>
+    /// Source identifier for the postcode lookup record, such as a local dataset or external API.
+    /// </summary>
+    public string Source { get; private set; } = string.Empty;
+    public DateTime LastVerifiedAtUtc { get; private set; }
+
+    public static PostcodeLookup Create(string postcode, decimal latitude, decimal longitude, string source)
+    {
+        return new PostcodeLookup
+        {
+            Postcode = postcode.Trim().ToUpperInvariant(),
+            Latitude = latitude,
+            Longitude = longitude,
+            Source = source.Trim(),
+            LastVerifiedAtUtc = DateTime.UtcNow
+        };
+    }
+
+    public void Refresh(decimal latitude, decimal longitude, string source, DateTime? verifiedAtUtc = null)
+    {
+        Latitude = latitude;
+        Longitude = longitude;
+        Source = source.Trim();
+        LastVerifiedAtUtc = verifiedAtUtc ?? DateTime.UtcNow;
+        Touch();
+    }
+}

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Domain/UserJobAiInsight.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Domain/UserJobAiInsight.cs
@@ -1,0 +1,87 @@
+using Firefly.Signal.SharedKernel.Domain;
+
+namespace Firefly.Signal.JobSearch.Domain;
+
+/// <summary>
+/// Persisted AI result for one user and one job, generated from a specific analysis request.
+/// </summary>
+public sealed class UserJobAiInsight : AuditableEntity, IAggregateRoot
+{
+    private UserJobAiInsight()
+    {
+    }
+
+    public long UserAccountId { get; private set; }
+    public long JobPostingId { get; private set; }
+    /// <summary>
+    /// Admin or privileged user who initiated the analysis for auditability.
+    /// </summary>
+    public long GeneratedByUserAccountId { get; private set; }
+    public long? AiAnalysisRunId { get; private set; }
+    /// <summary>
+    /// Fit rating returned by AI, constrained to a 1-5 star scale.
+    /// </summary>
+    public int Rating { get; private set; }
+    public string? Summary { get; private set; }
+    public string? DetailedExplanation { get; private set; }
+    public string? CvImprovementSuggestions { get; private set; }
+    public string? PromptVersion { get; private set; }
+    public DateTime GeneratedAtUtc { get; private set; }
+
+    public static UserJobAiInsight Create(
+        long userAccountId,
+        long jobPostingId,
+        long generatedByUserAccountId,
+        int rating,
+        string? summary,
+        string? detailedExplanation,
+        string? cvImprovementSuggestions,
+        string? promptVersion,
+        long? aiAnalysisRunId = null)
+    {
+        ValidateRating(rating);
+
+        return new UserJobAiInsight
+        {
+            UserAccountId = userAccountId,
+            JobPostingId = jobPostingId,
+            GeneratedByUserAccountId = generatedByUserAccountId,
+            AiAnalysisRunId = aiAnalysisRunId,
+            Rating = rating,
+            Summary = Normalize(summary),
+            DetailedExplanation = Normalize(detailedExplanation),
+            CvImprovementSuggestions = Normalize(cvImprovementSuggestions),
+            PromptVersion = Normalize(promptVersion),
+            GeneratedAtUtc = DateTime.UtcNow
+        };
+    }
+
+    public void UpdateResult(
+        int rating,
+        string? summary,
+        string? detailedExplanation,
+        string? cvImprovementSuggestions,
+        string? promptVersion,
+        long? aiAnalysisRunId = null)
+    {
+        ValidateRating(rating);
+        Rating = rating;
+        Summary = Normalize(summary);
+        DetailedExplanation = Normalize(detailedExplanation);
+        CvImprovementSuggestions = Normalize(cvImprovementSuggestions);
+        PromptVersion = Normalize(promptVersion);
+        AiAnalysisRunId = aiAnalysisRunId;
+        GeneratedAtUtc = DateTime.UtcNow;
+        Touch();
+    }
+
+    private static void ValidateRating(int rating)
+    {
+        if (rating is < 1 or > 5)
+        {
+            throw new ArgumentOutOfRangeException(nameof(rating), "AI rating must be between 1 and 5.");
+        }
+    }
+
+    private static string? Normalize(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Domain/UserJobState.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Domain/UserJobState.cs
@@ -1,0 +1,68 @@
+using Firefly.Signal.SharedKernel.Domain;
+
+namespace Firefly.Signal.JobSearch.Domain;
+
+/// <summary>
+/// Stores a user-specific workflow state for a job without mutating the shared job record.
+/// </summary>
+public sealed class UserJobState : AuditableEntity, IAggregateRoot
+{
+    private UserJobState()
+    {
+    }
+
+    public long UserAccountId { get; private set; }
+    public long JobPostingId { get; private set; }
+    public UserJobWorkflowState State { get; private set; }
+    public DateTime? SavedAtUtc { get; private set; }
+    public DateTime? AppliedAtUtc { get; private set; }
+    public DateTime? RejectedAtUtc { get; private set; }
+    /// <summary>
+    /// Explicit workflow timestamp kept separate from the shared audit fields for easier product-level state tracking.
+    /// </summary>
+    public DateTime LastUpdatedAtUtc { get; private set; }
+
+    public static UserJobState Create(long userAccountId, long jobPostingId, UserJobWorkflowState state)
+    {
+        var entity = new UserJobState
+        {
+            UserAccountId = userAccountId,
+            JobPostingId = jobPostingId
+        };
+
+        entity.SetState(state, DateTime.UtcNow);
+        return entity;
+    }
+
+    public void MarkSaved() => SetState(UserJobWorkflowState.Saved, DateTime.UtcNow);
+
+    public void MarkApplied() => SetState(UserJobWorkflowState.Applied, DateTime.UtcNow);
+
+    public void MarkRejected() => SetState(UserJobWorkflowState.Rejected, DateTime.UtcNow);
+
+    private void SetState(UserJobWorkflowState state, DateTime timestampUtc)
+    {
+        State = state;
+
+        if (state == UserJobWorkflowState.Saved)
+        {
+            SavedAtUtc ??= timestampUtc;
+            AppliedAtUtc = null;
+            RejectedAtUtc = null;
+        }
+        else if (state == UserJobWorkflowState.Applied)
+        {
+            SavedAtUtc ??= timestampUtc;
+            AppliedAtUtc ??= timestampUtc;
+            RejectedAtUtc = null;
+        }
+        else if (state == UserJobWorkflowState.Rejected)
+        {
+            SavedAtUtc ??= timestampUtc;
+            RejectedAtUtc ??= timestampUtc;
+        }
+
+        LastUpdatedAtUtc = timestampUtc;
+        Touch();
+    }
+}

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Domain/UserJobWorkflowState.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Domain/UserJobWorkflowState.cs
@@ -1,0 +1,8 @@
+namespace Firefly.Signal.JobSearch.Domain;
+
+public enum UserJobWorkflowState
+{
+    Saved = 1,
+    Applied = 2,
+    Rejected = 3
+}

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/Persistence/JobSearchDbContext.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/Persistence/JobSearchDbContext.cs
@@ -52,7 +52,9 @@ public sealed class JobSearchDbContext(DbContextOptions<JobSearchDbContext> opti
             entity.Property(x => x.ImportedAtUtc).IsRequired();
             entity.Property(x => x.LastSeenAtUtc).IsRequired();
             entity.Property(x => x.RawPayloadJson).HasColumnType("jsonb").IsRequired();
-            entity.HasIndex(x => new { x.SourceName, x.SourceJobId }).IsUnique();
+            entity.HasIndex(x => new { x.SourceName, x.SourceJobId })
+                .IsUnique()
+                .HasFilter("\"SourceJobId\" <> ''");
             entity.HasIndex(x => x.Postcode);
             entity.HasIndex(x => x.PostedAtUtc);
             entity.HasIndex(x => x.IsHidden);

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/Persistence/JobSearchDbContext.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/Persistence/JobSearchDbContext.cs
@@ -10,6 +10,13 @@ public sealed class JobSearchDbContext(DbContextOptions<JobSearchDbContext> opti
 
     public DbSet<JobPosting> Jobs => Set<JobPosting>();
     public DbSet<JobRefreshRun> JobRefreshRuns => Set<JobRefreshRun>();
+    public DbSet<PostcodeLookup> PostcodeLookups => Set<PostcodeLookup>();
+    public DbSet<UserJobState> UserJobStates => Set<UserJobState>();
+    public DbSet<JobApplication> JobApplications => Set<JobApplication>();
+    public DbSet<ApplicationNote> ApplicationNotes => Set<ApplicationNote>();
+    public DbSet<ApplicationDocumentLink> ApplicationDocumentLinks => Set<ApplicationDocumentLink>();
+    public DbSet<UserJobAiInsight> UserJobAiInsights => Set<UserJobAiInsight>();
+    public DbSet<AiAnalysisRun> AiAnalysisRuns => Set<AiAnalysisRun>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -45,10 +52,15 @@ public sealed class JobSearchDbContext(DbContextOptions<JobSearchDbContext> opti
             entity.Property(x => x.ImportedAtUtc).IsRequired();
             entity.Property(x => x.LastSeenAtUtc).IsRequired();
             entity.Property(x => x.RawPayloadJson).HasColumnType("jsonb").IsRequired();
+            entity.HasIndex(x => new { x.SourceName, x.SourceJobId }).IsUnique();
             entity.HasIndex(x => x.Postcode);
             entity.HasIndex(x => x.PostedAtUtc);
             entity.HasIndex(x => x.IsHidden);
             entity.HasIndex(x => x.SourceName);
+            entity.HasOne<JobRefreshRun>()
+                .WithMany()
+                .HasForeignKey(x => x.JobRefreshRunId)
+                .OnDelete(DeleteBehavior.SetNull);
         });
 
         modelBuilder.Entity<JobRefreshRun>(entity =>
@@ -67,6 +79,147 @@ public sealed class JobSearchDbContext(DbContextOptions<JobSearchDbContext> opti
             entity.Property(x => x.UpdatedAtUtc).IsRequired();
             entity.HasIndex(x => x.Status);
             entity.HasIndex(x => x.StartedAtUtc);
+        });
+
+        modelBuilder.Entity<PostcodeLookup>(entity =>
+        {
+            entity.ToTable("postcode_lookups");
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Id).ValueGeneratedNever();
+            entity.Property(x => x.Postcode).HasMaxLength(16).IsRequired();
+            entity.Property(x => x.Source).HasMaxLength(64).IsRequired();
+            entity.Property(x => x.LastVerifiedAtUtc).IsRequired();
+            entity.Property(x => x.CreatedAtUtc).IsRequired();
+            entity.Property(x => x.UpdatedAtUtc).IsRequired();
+            entity.HasIndex(x => x.Postcode).IsUnique();
+        });
+
+        modelBuilder.Entity<UserJobState>(entity =>
+        {
+            entity.ToTable("user_job_states");
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Id).ValueGeneratedNever();
+            entity.Property(x => x.UserAccountId).IsRequired();
+            entity.Property(x => x.JobPostingId).IsRequired();
+            entity.Property(x => x.State).HasConversion<string>().HasMaxLength(32).IsRequired();
+            entity.Property(x => x.SavedAtUtc);
+            entity.Property(x => x.AppliedAtUtc);
+            entity.Property(x => x.RejectedAtUtc);
+            entity.Property(x => x.LastUpdatedAtUtc).IsRequired();
+            entity.Property(x => x.CreatedAtUtc).IsRequired();
+            entity.Property(x => x.UpdatedAtUtc).IsRequired();
+            entity.HasIndex(x => new { x.UserAccountId, x.JobPostingId }).IsUnique();
+            entity.HasIndex(x => new { x.UserAccountId, x.State });
+            entity.HasOne<JobPosting>()
+                .WithMany()
+                .HasForeignKey(x => x.JobPostingId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<JobApplication>(entity =>
+        {
+            entity.ToTable("job_applications");
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Id).ValueGeneratedNever();
+            entity.Property(x => x.UserAccountId).IsRequired();
+            entity.Property(x => x.JobPostingId).IsRequired();
+            entity.Property(x => x.AppliedAtUtc).IsRequired();
+            entity.Property(x => x.Status).HasConversion<string>().HasMaxLength(32).IsRequired();
+            entity.Property(x => x.SubmittedCvDocumentId);
+            entity.Property(x => x.SubmittedCoverLetterDocumentId);
+            entity.Property(x => x.RejectionAtUtc);
+            entity.Property(x => x.RejectionReason).HasMaxLength(2000);
+            entity.Property(x => x.CreatedAtUtc).IsRequired();
+            entity.Property(x => x.UpdatedAtUtc).IsRequired();
+            entity.HasIndex(x => new { x.UserAccountId, x.JobPostingId }).IsUnique();
+            entity.HasIndex(x => new { x.UserAccountId, x.Status });
+            entity.HasOne<JobPosting>()
+                .WithMany()
+                .HasForeignKey(x => x.JobPostingId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<ApplicationNote>(entity =>
+        {
+            entity.ToTable("application_notes");
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Id).ValueGeneratedNever();
+            entity.Property(x => x.JobApplicationId).IsRequired();
+            entity.Property(x => x.UserAccountId).IsRequired();
+            entity.Property(x => x.Body).HasMaxLength(4000).IsRequired();
+            entity.Property(x => x.CreatedAtUtc).IsRequired();
+            entity.Property(x => x.UpdatedAtUtc).IsRequired();
+            entity.HasIndex(x => x.JobApplicationId);
+            entity.HasOne<JobApplication>()
+                .WithMany()
+                .HasForeignKey(x => x.JobApplicationId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<ApplicationDocumentLink>(entity =>
+        {
+            entity.ToTable("application_document_links");
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Id).ValueGeneratedNever();
+            entity.Property(x => x.JobApplicationId).IsRequired();
+            entity.Property(x => x.UserDocumentId).IsRequired();
+            entity.Property(x => x.LinkType).HasConversion<string>().HasMaxLength(48).IsRequired();
+            entity.Property(x => x.CreatedAtUtc).IsRequired();
+            entity.Property(x => x.UpdatedAtUtc).IsRequired();
+            entity.HasIndex(x => x.JobApplicationId);
+            entity.HasIndex(x => new { x.JobApplicationId, x.UserDocumentId, x.LinkType }).IsUnique();
+            entity.HasOne<JobApplication>()
+                .WithMany()
+                .HasForeignKey(x => x.JobApplicationId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<AiAnalysisRun>(entity =>
+        {
+            entity.ToTable("ai_analysis_runs");
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Id).ValueGeneratedNever();
+            entity.Property(x => x.RequestedByUserAccountId).IsRequired();
+            entity.Property(x => x.TargetUserAccountId).IsRequired();
+            entity.Property(x => x.Mode).HasConversion<string>().HasMaxLength(32).IsRequired();
+            entity.Property(x => x.Status).HasConversion<string>().HasMaxLength(32).IsRequired();
+            entity.Property(x => x.JobCount).IsRequired();
+            entity.Property(x => x.StartedAtUtc).IsRequired();
+            entity.Property(x => x.CompletedAtUtc);
+            entity.Property(x => x.FailureSummary).HasMaxLength(2000);
+            entity.Property(x => x.CreatedAtUtc).IsRequired();
+            entity.Property(x => x.UpdatedAtUtc).IsRequired();
+            entity.HasIndex(x => x.Status);
+            entity.HasIndex(x => x.StartedAtUtc);
+        });
+
+        modelBuilder.Entity<UserJobAiInsight>(entity =>
+        {
+            entity.ToTable("user_job_ai_insights");
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Id).ValueGeneratedNever();
+            entity.Property(x => x.UserAccountId).IsRequired();
+            entity.Property(x => x.JobPostingId).IsRequired();
+            entity.Property(x => x.GeneratedByUserAccountId).IsRequired();
+            entity.Property(x => x.AiAnalysisRunId);
+            entity.Property(x => x.Rating).IsRequired();
+            entity.Property(x => x.Summary).HasMaxLength(4000);
+            entity.Property(x => x.DetailedExplanation).HasMaxLength(12000);
+            entity.Property(x => x.CvImprovementSuggestions).HasMaxLength(12000);
+            entity.Property(x => x.PromptVersion).HasMaxLength(128);
+            entity.Property(x => x.GeneratedAtUtc).IsRequired();
+            entity.Property(x => x.CreatedAtUtc).IsRequired();
+            entity.Property(x => x.UpdatedAtUtc).IsRequired();
+            entity.HasIndex(x => new { x.UserAccountId, x.JobPostingId, x.GeneratedAtUtc });
+            entity.HasIndex(x => x.AiAnalysisRunId);
+            entity.HasOne<JobPosting>()
+                .WithMany()
+                .HasForeignKey(x => x.JobPostingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasOne<AiAnalysisRun>()
+                .WithMany()
+                .HasForeignKey(x => x.AiAnalysisRunId)
+                .OnDelete(DeleteBehavior.SetNull);
         });
 
         modelBuilder.ApplySoftDeleteQueryFilters();

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/Persistence/Migrations/20260411125508_AddWorkflowAndAiDomain.Designer.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/Persistence/Migrations/20260411125508_AddWorkflowAndAiDomain.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Firefly.Signal.JobSearch.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Firefly.Signal.JobSearch.Api.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(JobSearchDbContext))]
-    partial class JobSearchDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411125508_AddWorkflowAndAiDomain")]
+    partial class AddWorkflowAndAiDomain
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/Persistence/Migrations/20260411125508_AddWorkflowAndAiDomain.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/Persistence/Migrations/20260411125508_AddWorkflowAndAiDomain.cs
@@ -1,0 +1,371 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Firefly.Signal.JobSearch.Api.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorkflowAndAiDomain : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ai_analysis_runs",
+                schema: "jobsearch",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    RequestedByUserAccountId = table.Column<long>(type: "bigint", nullable: false),
+                    TargetUserAccountId = table.Column<long>(type: "bigint", nullable: false),
+                    Mode = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    JobCount = table.Column<int>(type: "integer", nullable: false),
+                    StartedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CompletedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    FailureSummary = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ai_analysis_runs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "job_applications",
+                schema: "jobsearch",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    UserAccountId = table.Column<long>(type: "bigint", nullable: false),
+                    JobPostingId = table.Column<long>(type: "bigint", nullable: false),
+                    AppliedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    SubmittedCvDocumentId = table.Column<long>(type: "bigint", nullable: true),
+                    SubmittedCoverLetterDocumentId = table.Column<long>(type: "bigint", nullable: true),
+                    RejectionAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    RejectionReason = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_job_applications", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_job_applications_jobs_JobPostingId",
+                        column: x => x.JobPostingId,
+                        principalSchema: "jobsearch",
+                        principalTable: "jobs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "postcode_lookups",
+                schema: "jobsearch",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    Postcode = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    Latitude = table.Column<decimal>(type: "numeric", nullable: false),
+                    Longitude = table.Column<decimal>(type: "numeric", nullable: false),
+                    Source = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    LastVerifiedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_postcode_lookups", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "user_job_states",
+                schema: "jobsearch",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    UserAccountId = table.Column<long>(type: "bigint", nullable: false),
+                    JobPostingId = table.Column<long>(type: "bigint", nullable: false),
+                    State = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    SavedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    AppliedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    RejectedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastUpdatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_user_job_states", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_user_job_states_jobs_JobPostingId",
+                        column: x => x.JobPostingId,
+                        principalSchema: "jobsearch",
+                        principalTable: "jobs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "user_job_ai_insights",
+                schema: "jobsearch",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    UserAccountId = table.Column<long>(type: "bigint", nullable: false),
+                    JobPostingId = table.Column<long>(type: "bigint", nullable: false),
+                    GeneratedByUserAccountId = table.Column<long>(type: "bigint", nullable: false),
+                    AiAnalysisRunId = table.Column<long>(type: "bigint", nullable: true),
+                    Rating = table.Column<int>(type: "integer", nullable: false),
+                    Summary = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
+                    DetailedExplanation = table.Column<string>(type: "character varying(12000)", maxLength: 12000, nullable: true),
+                    CvImprovementSuggestions = table.Column<string>(type: "character varying(12000)", maxLength: 12000, nullable: true),
+                    PromptVersion = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    GeneratedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_user_job_ai_insights", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_user_job_ai_insights_ai_analysis_runs_AiAnalysisRunId",
+                        column: x => x.AiAnalysisRunId,
+                        principalSchema: "jobsearch",
+                        principalTable: "ai_analysis_runs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_user_job_ai_insights_jobs_JobPostingId",
+                        column: x => x.JobPostingId,
+                        principalSchema: "jobsearch",
+                        principalTable: "jobs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "application_document_links",
+                schema: "jobsearch",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    JobApplicationId = table.Column<long>(type: "bigint", nullable: false),
+                    UserDocumentId = table.Column<long>(type: "bigint", nullable: false),
+                    LinkType = table.Column<string>(type: "character varying(48)", maxLength: 48, nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_application_document_links", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_application_document_links_job_applications_JobApplicationId",
+                        column: x => x.JobApplicationId,
+                        principalSchema: "jobsearch",
+                        principalTable: "job_applications",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "application_notes",
+                schema: "jobsearch",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    JobApplicationId = table.Column<long>(type: "bigint", nullable: false),
+                    UserAccountId = table.Column<long>(type: "bigint", nullable: false),
+                    Body = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_application_notes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_application_notes_job_applications_JobApplicationId",
+                        column: x => x.JobApplicationId,
+                        principalSchema: "jobsearch",
+                        principalTable: "job_applications",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_jobs_JobRefreshRunId",
+                schema: "jobsearch",
+                table: "jobs",
+                column: "JobRefreshRunId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_jobs_SourceName_SourceJobId",
+                schema: "jobsearch",
+                table: "jobs",
+                columns: new[] { "SourceName", "SourceJobId" },
+                unique: true,
+                filter: "\"SourceJobId\" <> ''");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ai_analysis_runs_StartedAtUtc",
+                schema: "jobsearch",
+                table: "ai_analysis_runs",
+                column: "StartedAtUtc");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ai_analysis_runs_Status",
+                schema: "jobsearch",
+                table: "ai_analysis_runs",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_application_document_links_JobApplicationId",
+                schema: "jobsearch",
+                table: "application_document_links",
+                column: "JobApplicationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_application_document_links_JobApplicationId_UserDocumentId_~",
+                schema: "jobsearch",
+                table: "application_document_links",
+                columns: new[] { "JobApplicationId", "UserDocumentId", "LinkType" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_application_notes_JobApplicationId",
+                schema: "jobsearch",
+                table: "application_notes",
+                column: "JobApplicationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_job_applications_JobPostingId",
+                schema: "jobsearch",
+                table: "job_applications",
+                column: "JobPostingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_job_applications_UserAccountId_JobPostingId",
+                schema: "jobsearch",
+                table: "job_applications",
+                columns: new[] { "UserAccountId", "JobPostingId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_job_applications_UserAccountId_Status",
+                schema: "jobsearch",
+                table: "job_applications",
+                columns: new[] { "UserAccountId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_postcode_lookups_Postcode",
+                schema: "jobsearch",
+                table: "postcode_lookups",
+                column: "Postcode",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_job_ai_insights_AiAnalysisRunId",
+                schema: "jobsearch",
+                table: "user_job_ai_insights",
+                column: "AiAnalysisRunId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_job_ai_insights_JobPostingId",
+                schema: "jobsearch",
+                table: "user_job_ai_insights",
+                column: "JobPostingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_job_ai_insights_UserAccountId_JobPostingId_GeneratedAt~",
+                schema: "jobsearch",
+                table: "user_job_ai_insights",
+                columns: new[] { "UserAccountId", "JobPostingId", "GeneratedAtUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_job_states_JobPostingId",
+                schema: "jobsearch",
+                table: "user_job_states",
+                column: "JobPostingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_job_states_UserAccountId_JobPostingId",
+                schema: "jobsearch",
+                table: "user_job_states",
+                columns: new[] { "UserAccountId", "JobPostingId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_job_states_UserAccountId_State",
+                schema: "jobsearch",
+                table: "user_job_states",
+                columns: new[] { "UserAccountId", "State" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_jobs_job_refresh_runs_JobRefreshRunId",
+                schema: "jobsearch",
+                table: "jobs",
+                column: "JobRefreshRunId",
+                principalSchema: "jobsearch",
+                principalTable: "job_refresh_runs",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_jobs_job_refresh_runs_JobRefreshRunId",
+                schema: "jobsearch",
+                table: "jobs");
+
+            migrationBuilder.DropTable(
+                name: "application_document_links",
+                schema: "jobsearch");
+
+            migrationBuilder.DropTable(
+                name: "application_notes",
+                schema: "jobsearch");
+
+            migrationBuilder.DropTable(
+                name: "postcode_lookups",
+                schema: "jobsearch");
+
+            migrationBuilder.DropTable(
+                name: "user_job_ai_insights",
+                schema: "jobsearch");
+
+            migrationBuilder.DropTable(
+                name: "user_job_states",
+                schema: "jobsearch");
+
+            migrationBuilder.DropTable(
+                name: "job_applications",
+                schema: "jobsearch");
+
+            migrationBuilder.DropTable(
+                name: "ai_analysis_runs",
+                schema: "jobsearch");
+
+            migrationBuilder.DropIndex(
+                name: "IX_jobs_JobRefreshRunId",
+                schema: "jobsearch",
+                table: "jobs");
+
+            migrationBuilder.DropIndex(
+                name: "IX_jobs_SourceName_SourceJobId",
+                schema: "jobsearch",
+                table: "jobs");
+        }
+    }
+}


### PR DESCRIPTION
Closes #36

## Summary
- add and map the first-pass MVP workflow schema for identity profile/documents and job workflow/AI persistence
- generate EF migrations for both Identity and Job Search contexts
- update the local Docker-backed PostgreSQL database to the latest schema
- fix the job uniqueness rule so provider IDs are only enforced when a source job id is present

## Validation
- dotnet build services/api/Firefly.Signal.Api.slnx
- dotnet ef database update for Identity API
- dotnet ef database update for Job Search API

## Notes
- `dotnet-ef` was updated locally from 9.0.3 to 10.0.5 during this work
