### PR TITLE
feat(identity): add S3-backed user document management (#42)

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   preflight:
+    environment: production
     runs-on: ubuntu-latest
     outputs:
       deploy_ready: ${{ steps.deploy.outputs.ready }}
@@ -31,8 +32,13 @@ jobs:
           RABBITMQ_DEFAULT_PASS: ${{ secrets.RABBITMQ_DEFAULT_PASS }}
           DOCKERHUB_NAMESPACE: ${{ secrets.DOCKERHUB_NAMESPACE }}
           CORS_ALLOWED_ORIGIN: ${{ secrets.CORS_ALLOWED_ORIGIN }}
+          IDENTITY_S3_BUCKET_NAME: ${{ secrets.IDENTITY_S3_BUCKET_NAME }}
+          IDENTITY_S3_REGION: ${{ secrets.IDENTITY_S3_REGION }}
+          IDENTITY_S3_KEY_PREFIX: ${{ secrets.IDENTITY_S3_KEY_PREFIX }}
+          IDENTITY_S3_ACCESS_KEY_ID: ${{ secrets.IDENTITY_S3_ACCESS_KEY_ID }}
+          IDENTITY_S3_SECRET_ACCESS_KEY: ${{ secrets.IDENTITY_S3_SECRET_ACCESS_KEY }}
         run: |
-          if [ -n "$DEPLOY_SSH_HOST" ] && [ -n "$DEPLOY_SSH_PORT" ] && [ -n "$DEPLOY_SSH_USERNAME" ] && [ -n "$DEPLOY_SSH_PRIVATE_KEY" ] && [ -n "$DEPLOY_REMOTE_PATH" ] && [ -n "$JWT_SIGNING_KEY" ] && [ -n "$POSTGRES_USER" ] && [ -n "$POSTGRES_PASSWORD" ] && [ -n "$POSTGRES_DB" ] && [ -n "$RABBITMQ_DEFAULT_USER" ] && [ -n "$RABBITMQ_DEFAULT_PASS" ] && [ -n "$DOCKERHUB_NAMESPACE" ] && [ -n "$CORS_ALLOWED_ORIGIN" ]; then
+          if [ -n "$DEPLOY_SSH_HOST" ] && [ -n "$DEPLOY_SSH_PORT" ] && [ -n "$DEPLOY_SSH_USERNAME" ] && [ -n "$DEPLOY_SSH_PRIVATE_KEY" ] && [ -n "$DEPLOY_REMOTE_PATH" ] && [ -n "$JWT_SIGNING_KEY" ] && [ -n "$POSTGRES_USER" ] && [ -n "$POSTGRES_PASSWORD" ] && [ -n "$POSTGRES_DB" ] && [ -n "$RABBITMQ_DEFAULT_USER" ] && [ -n "$RABBITMQ_DEFAULT_PASS" ] && [ -n "$DOCKERHUB_NAMESPACE" ] && [ -n "$CORS_ALLOWED_ORIGIN" ] && [ -n "$IDENTITY_S3_BUCKET_NAME" ] && [ -n "$IDENTITY_S3_REGION" ] && [ -n "$IDENTITY_S3_KEY_PREFIX" ] && [ -n "$IDENTITY_S3_ACCESS_KEY_ID" ] && [ -n "$IDENTITY_S3_SECRET_ACCESS_KEY" ]; then
             echo "ready=true" >> "$GITHUB_OUTPUT"
           else
             echo "ready=false" >> "$GITHUB_OUTPUT"
@@ -41,6 +47,7 @@ jobs:
   deploy:
     needs: preflight
     if: needs.preflight.outputs.deploy_ready == 'true'
+    environment: production
     runs-on: ubuntu-latest
     env:
       DEPLOY_SSH_HOST: ${{ secrets.DEPLOY_SSH_HOST }}
@@ -55,6 +62,11 @@ jobs:
       RABBITMQ_DEFAULT_PASS: ${{ secrets.RABBITMQ_DEFAULT_PASS }}
       DOCKERHUB_NAMESPACE: ${{ secrets.DOCKERHUB_NAMESPACE }}
       CORS_ALLOWED_ORIGIN: ${{ secrets.CORS_ALLOWED_ORIGIN }}
+      IDENTITY_S3_BUCKET_NAME: ${{ secrets.IDENTITY_S3_BUCKET_NAME }}
+      IDENTITY_S3_REGION: ${{ secrets.IDENTITY_S3_REGION }}
+      IDENTITY_S3_KEY_PREFIX: ${{ secrets.IDENTITY_S3_KEY_PREFIX }}
+      IDENTITY_S3_ACCESS_KEY_ID: ${{ secrets.IDENTITY_S3_ACCESS_KEY_ID }}
+      IDENTITY_S3_SECRET_ACCESS_KEY: ${{ secrets.IDENTITY_S3_SECRET_ACCESS_KEY }}
       IMAGE_TAG: ${{ inputs.image_tag }}
 
     steps:
@@ -87,6 +99,11 @@ jobs:
           JWT_SIGNING_KEY=${JWT_SIGNING_KEY}
           DOCKERHUB_NAMESPACE=${DOCKERHUB_NAMESPACE}
           CORS_ALLOWED_ORIGIN=${CORS_ALLOWED_ORIGIN}
+          IDENTITY_S3_BUCKET_NAME=${IDENTITY_S3_BUCKET_NAME}
+          IDENTITY_S3_REGION=${IDENTITY_S3_REGION}
+          IDENTITY_S3_KEY_PREFIX=${IDENTITY_S3_KEY_PREFIX}
+          IDENTITY_S3_ACCESS_KEY_ID=${IDENTITY_S3_ACCESS_KEY_ID}
+          IDENTITY_S3_SECRET_ACCESS_KEY=${IDENTITY_S3_SECRET_ACCESS_KEY}
           IMAGE_TAG=${IMAGE_TAG}
           EOF
 

--- a/docs/backend-designs.md
+++ b/docs/backend-designs.md
@@ -113,8 +113,8 @@ The MVP is not a stateless search-only product.
 Persisted workflow data is part of the core requirement.
 
 ### File Storage
-Use a simple local-first file storage approach for uploaded CVs, cover letters, and other user files during the MVP.
-Persist document metadata in PostgreSQL and keep storage implementation easy to replace later.
+Use Amazon S3 for uploaded CVs, cover letters, and other user-owned files during the MVP.
+Persist document metadata in PostgreSQL and keep the relational model separate from binary storage concerns.
 
 ### Redis
 Use Redis only if needed for:
@@ -179,7 +179,6 @@ Do not force async workflows into the first implementation if synchronous reques
 
 ## Open Questions
 - Which provider or providers should be implemented first for dependable UK developer-job coverage?
-- Should uploaded document binaries stay on local disk for the full MVP, or move earlier to a managed object store?
 - Does postcode-distance filtering rely on a local postcode lookup dataset, an external postcode API, or both?
 
 ## Current Recommendation

--- a/docs/backend-designs/data-model-plan.md
+++ b/docs/backend-designs/data-model-plan.md
@@ -102,6 +102,7 @@ Recommended `DocumentType` values:
 Notes:
 - store binary files outside the relational row
 - keep metadata in PostgreSQL
+- use the `StorageKey` as the Amazon S3 object key for the uploaded file
 
 ## Job Search Domain Entities
 ### JobRefreshRun

--- a/docs/product-requirements-document.md
+++ b/docs/product-requirements-document.md
@@ -180,6 +180,7 @@ The MVP should already include these core capabilities in a practical single-use
 - Saved and applied states are persisted per user.
 - Notes are persisted per application or job workflow record.
 - Uploaded document metadata is persisted in the database.
+- Uploaded document binaries are stored in Amazon S3.
 - AI outputs are persisted and linked to both user and job context.
 
 ## Quality Attributes
@@ -215,7 +216,6 @@ The MVP should already include these core capabilities in a practical single-use
 
 ## Deliberately Deferred Decisions
 - Exact provider order after the first live provider is integrated
-- Exact long-term storage backend for document binaries beyond the MVP local-first path
 - Whether scraping becomes necessary for provider coverage after public API evaluation
 - Whether future non-admin roles beyond `test-admin` are justified
 

--- a/infra/deploy/docker-compose.production.yml
+++ b/infra/deploy/docker-compose.production.yml
@@ -55,6 +55,11 @@ services:
       ASPNETCORE_HTTP_PORTS: 8080
       ConnectionStrings__FireflySignalDb: Host=postgres;Port=5432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}
       Jwt__SigningKey: ${JWT_SIGNING_KEY}
+      UserDocumentStorage__BucketName: ${IDENTITY_S3_BUCKET_NAME}
+      UserDocumentStorage__Region: ${IDENTITY_S3_REGION}
+      UserDocumentStorage__KeyPrefix: ${IDENTITY_S3_KEY_PREFIX}
+      UserDocumentStorage__AccessKeyId: ${IDENTITY_S3_ACCESS_KEY_ID}
+      UserDocumentStorage__SecretAccessKey: ${IDENTITY_S3_SECRET_ACCESS_KEY}
     depends_on:
       postgres:
         condition: service_healthy

--- a/services/api/Directory.Packages.props
+++ b/services/api/Directory.Packages.props
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.13.1" />
     <PackageVersion Include="Asp.Versioning.Http" Version="$(ApiVersioningVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(DotnetPackagesVersion)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="$(DotnetPackagesVersion)" />

--- a/services/api/src/Firefly.Signal.Identity.Api/Application/UserDocumentContracts.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Application/UserDocumentContracts.cs
@@ -1,0 +1,81 @@
+using Firefly.Signal.Identity.Domain;
+using Microsoft.AspNetCore.Http;
+
+namespace Firefly.Signal.Identity.Application;
+
+public sealed class UploadUserDocumentRequest
+{
+    public string DocumentType { get; set; } = string.Empty;
+    public string? DisplayName { get; set; }
+    public bool IsDefault { get; set; }
+    public IFormFile? File { get; set; }
+}
+
+public sealed record UserDocumentResponse(
+    long Id,
+    string DocumentType,
+    string DisplayName,
+    string OriginalFileName,
+    string StorageKey,
+    string ContentType,
+    long FileSizeBytes,
+    string ChecksumSha256,
+    bool IsDefault,
+    bool SupportsDefaultSelection,
+    DateTime UploadedAtUtc,
+    DateTime CreatedAtUtc,
+    DateTime UpdatedAtUtc);
+
+public static class UserDocumentContractMappings
+{
+    public static UserDocumentResponse ToResponse(this UserDocument document)
+        => new(
+            document.Id,
+            ToApiDocumentType(document.DocumentType),
+            document.DisplayName,
+            document.OriginalFileName,
+            document.StorageKey,
+            document.ContentType,
+            document.FileSizeBytes,
+            document.ChecksumSha256,
+            document.IsDefault,
+            SupportsDefaultSelection(document.DocumentType),
+            document.UploadedAtUtc,
+            document.CreatedAtUtc,
+            document.UpdatedAtUtc);
+
+    public static bool TryParseDocumentType(string? value, out UserDocumentType documentType)
+    {
+        switch (value?.Trim().ToLowerInvariant())
+        {
+            case "cv":
+                documentType = UserDocumentType.Cv;
+                return true;
+            case "cover-letter":
+                documentType = UserDocumentType.CoverLetter;
+                return true;
+            case "profile-supporting":
+                documentType = UserDocumentType.ProfileSupporting;
+                return true;
+            case "other":
+                documentType = UserDocumentType.Other;
+                return true;
+            default:
+                documentType = default;
+                return false;
+        }
+    }
+
+    public static bool SupportsDefaultSelection(UserDocumentType documentType)
+        => documentType is UserDocumentType.Cv or UserDocumentType.CoverLetter;
+
+    private static string ToApiDocumentType(UserDocumentType documentType)
+        => documentType switch
+        {
+            UserDocumentType.Cv => "cv",
+            UserDocumentType.CoverLetter => "cover-letter",
+            UserDocumentType.ProfileSupporting => "profile-supporting",
+            UserDocumentType.Other => "other",
+            _ => documentType.ToString().ToLowerInvariant()
+        };
+}

--- a/services/api/src/Firefly.Signal.Identity.Api/Endpoints/UserDocumentEndpoints.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Endpoints/UserDocumentEndpoints.cs
@@ -1,0 +1,321 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using Firefly.Signal.Identity.Application;
+using Firefly.Signal.Identity.Domain;
+using Firefly.Signal.Identity.Infrastructure.Persistence;
+using Firefly.Signal.Identity.Infrastructure.Storage;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace Firefly.Signal.Identity.Endpoints;
+
+public static class UserDocumentEndpoints
+{
+    public static IEndpointRouteBuilder MapUserDocumentEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/documents").RequireAuthorization();
+
+        group.MapGet("/", ListAsync);
+        group.MapGet("/{id:long}", GetByIdAsync);
+        group.MapPost("/", UploadAsync)
+            .Accepts<UploadUserDocumentRequest>("multipart/form-data")
+            .DisableAntiforgery();
+        group.MapPost("/{id:long}/default", SetDefaultAsync);
+        group.MapDelete("/{id:long}", DeleteAsync);
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> ListAsync(
+        ClaimsPrincipal claimsPrincipal,
+        IdentityDbContext dbContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = GetCurrentUserId(claimsPrincipal);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var documents = await dbContext.UserDocuments
+            .Where(x => x.UserAccountId == userId.Value)
+            .OrderByDescending(x => x.IsDefault)
+            .ThenByDescending(x => x.UploadedAtUtc)
+            .Select(x => x.ToResponse())
+            .ToListAsync(cancellationToken);
+
+        return Results.Ok(documents);
+    }
+
+    private static async Task<IResult> GetByIdAsync(
+        long id,
+        ClaimsPrincipal claimsPrincipal,
+        IdentityDbContext dbContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = GetCurrentUserId(claimsPrincipal);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var document = await dbContext.UserDocuments
+            .SingleOrDefaultAsync(x => x.Id == id && x.UserAccountId == userId.Value, cancellationToken);
+
+        return document is null ? Results.NotFound() : Results.Ok(document.ToResponse());
+    }
+
+    private static async Task<IResult> UploadAsync(
+        [FromForm] UploadUserDocumentRequest request,
+        ClaimsPrincipal claimsPrincipal,
+        IdentityDbContext dbContext,
+        IUserDocumentStorage documentStorage,
+        IOptions<UserDocumentStorageOptions> storageOptions,
+        CancellationToken cancellationToken)
+    {
+        var userId = GetCurrentUserId(claimsPrincipal);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var validationErrors = ValidateUploadRequest(request, storageOptions.Value);
+        if (validationErrors.Count > 0)
+        {
+            return Results.ValidationProblem(validationErrors);
+        }
+
+        if (!UserDocumentContractMappings.TryParseDocumentType(request.DocumentType, out var documentType))
+        {
+            return Results.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["documentType"] = ["Document type must be one of cv, cover-letter, profile-supporting, or other."]
+            });
+        }
+
+        if (!await dbContext.Users.AnyAsync(x => x.Id == userId.Value, cancellationToken))
+        {
+            return Results.Unauthorized();
+        }
+
+        var file = request.File!;
+        await using var uploadStream = new MemoryStream();
+        await file.CopyToAsync(uploadStream, cancellationToken);
+        var contentBytes = uploadStream.ToArray();
+        var checksumSha256 = Convert.ToHexString(SHA256.HashData(contentBytes)).ToLowerInvariant();
+        var originalFileName = Path.GetFileName(file.FileName.Trim());
+        var displayName = string.IsNullOrWhiteSpace(request.DisplayName)
+            ? Path.GetFileNameWithoutExtension(originalFileName)
+            : request.DisplayName.Trim();
+
+        var supportsDefaultSelection = UserDocumentContractMappings.SupportsDefaultSelection(documentType);
+        if (request.IsDefault && !supportsDefaultSelection)
+        {
+            return Results.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["isDefault"] = ["Only CV and cover-letter documents support default selection."]
+            });
+        }
+
+        var hasExistingDefault = supportsDefaultSelection && await dbContext.UserDocuments
+            .AnyAsync(
+                x => x.UserAccountId == userId.Value
+                    && x.DocumentType == documentType
+                    && x.IsDefault,
+                cancellationToken);
+
+        var isDefault = supportsDefaultSelection && (request.IsDefault || !hasExistingDefault);
+        var storedDocument = await documentStorage.UploadAsync(
+            new UserDocumentUploadRequest(
+                userId.Value,
+                request.DocumentType.Trim().ToLowerInvariant(),
+                originalFileName,
+                file.ContentType.Trim(),
+                contentBytes,
+                checksumSha256),
+            cancellationToken);
+
+        try
+        {
+            if (isDefault)
+            {
+                await ClearDefaultDocumentsAsync(userId.Value, documentType, dbContext, cancellationToken);
+            }
+
+            var document = UserDocument.Create(
+                userId.Value,
+                documentType,
+                displayName,
+                originalFileName,
+                storedDocument.StorageKey,
+                file.ContentType.Trim(),
+                file.Length,
+                checksumSha256,
+                isDefault);
+
+            dbContext.UserDocuments.Add(document);
+            await dbContext.SaveChangesAsync(cancellationToken);
+
+            return Results.Created($"/api/documents/{document.Id}", document.ToResponse());
+        }
+        catch
+        {
+            await documentStorage.DeleteAsync(storedDocument.StorageKey, cancellationToken);
+            throw;
+        }
+    }
+
+    private static async Task<IResult> SetDefaultAsync(
+        long id,
+        ClaimsPrincipal claimsPrincipal,
+        IdentityDbContext dbContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = GetCurrentUserId(claimsPrincipal);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var document = await dbContext.UserDocuments
+            .SingleOrDefaultAsync(x => x.Id == id && x.UserAccountId == userId.Value, cancellationToken);
+
+        if (document is null)
+        {
+            return Results.NotFound();
+        }
+
+        if (!UserDocumentContractMappings.SupportsDefaultSelection(document.DocumentType))
+        {
+            return Results.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["id"] = ["Only CV and cover-letter documents can be marked as default."]
+            });
+        }
+
+        await ClearDefaultDocumentsAsync(userId.Value, document.DocumentType, dbContext, cancellationToken);
+        document.MarkDefault();
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Results.Ok(document.ToResponse());
+    }
+
+    private static async Task<IResult> DeleteAsync(
+        long id,
+        ClaimsPrincipal claimsPrincipal,
+        IdentityDbContext dbContext,
+        IUserDocumentStorage documentStorage,
+        CancellationToken cancellationToken)
+    {
+        var userId = GetCurrentUserId(claimsPrincipal);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var document = await dbContext.UserDocuments
+            .SingleOrDefaultAsync(x => x.Id == id && x.UserAccountId == userId.Value, cancellationToken);
+
+        if (document is null)
+        {
+            return Results.NotFound();
+        }
+
+        await documentStorage.DeleteAsync(document.StorageKey, cancellationToken);
+
+        var wasDefault = document.IsDefault;
+        var documentType = document.DocumentType;
+
+        document.MarkDeleted();
+        document.ClearDefault();
+
+        if (wasDefault && UserDocumentContractMappings.SupportsDefaultSelection(documentType))
+        {
+            var replacementDocument = await dbContext.UserDocuments
+                .Where(x => x.UserAccountId == userId.Value && x.DocumentType == documentType && x.Id != document.Id)
+                .OrderByDescending(x => x.UploadedAtUtc)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            replacementDocument?.MarkDefault();
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return Results.NoContent();
+    }
+
+    private static async Task ClearDefaultDocumentsAsync(
+        long userId,
+        UserDocumentType documentType,
+        IdentityDbContext dbContext,
+        CancellationToken cancellationToken)
+    {
+        var defaultDocuments = await dbContext.UserDocuments
+            .Where(x => x.UserAccountId == userId && x.DocumentType == documentType && x.IsDefault)
+            .ToListAsync(cancellationToken);
+
+        foreach (var defaultDocument in defaultDocuments)
+        {
+            defaultDocument.ClearDefault();
+        }
+    }
+
+    private static Dictionary<string, string[]> ValidateUploadRequest(
+        UploadUserDocumentRequest request,
+        UserDocumentStorageOptions storageOptions)
+    {
+        var validationErrors = new Dictionary<string, string[]>();
+
+        if (request.File is null)
+        {
+            validationErrors["file"] = ["A document file is required."];
+            return validationErrors;
+        }
+
+        if (string.IsNullOrWhiteSpace(request.DocumentType))
+        {
+            validationErrors["documentType"] = ["Document type is required."];
+        }
+
+        if (request.File.Length <= 0)
+        {
+            validationErrors["file"] = ["The uploaded file must not be empty."];
+        }
+
+        if (request.File.Length > storageOptions.MaxFileSizeBytes)
+        {
+            validationErrors["file"] = [$"The uploaded file exceeds the {storageOptions.MaxFileSizeBytes} byte limit."];
+        }
+
+        var fileName = Path.GetFileName(request.File.FileName ?? string.Empty);
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            validationErrors["fileName"] = ["A valid original file name is required."];
+        }
+
+        var extension = Path.GetExtension(fileName).ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(extension) || !storageOptions.AllowedFileExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
+        {
+            validationErrors["fileExtension"] =
+                [$"The uploaded file extension must be one of: {string.Join(", ", storageOptions.AllowedFileExtensions)}."];
+        }
+
+        var contentType = request.File.ContentType?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(contentType) || !storageOptions.AllowedContentTypes.Contains(contentType, StringComparer.OrdinalIgnoreCase))
+        {
+            validationErrors["contentType"] =
+                [$"The uploaded content type must be one of: {string.Join(", ", storageOptions.AllowedContentTypes)}."];
+        }
+
+        return validationErrors;
+    }
+
+    private static long? GetCurrentUserId(ClaimsPrincipal claimsPrincipal)
+    {
+        var subject = claimsPrincipal.FindFirstValue(JwtRegisteredClaimNames.Sub)
+            ?? claimsPrincipal.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        return long.TryParse(subject, out var userId) ? userId : null;
+    }
+}

--- a/services/api/src/Firefly.Signal.Identity.Api/Firefly.Signal.Identity.Api.csproj
+++ b/services/api/src/Firefly.Signal.Identity.Api/Firefly.Signal.Identity.Api.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />

--- a/services/api/src/Firefly.Signal.Identity.Api/Infrastructure/Storage/IUserDocumentStorage.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Infrastructure/Storage/IUserDocumentStorage.cs
@@ -1,0 +1,17 @@
+namespace Firefly.Signal.Identity.Infrastructure.Storage;
+
+public interface IUserDocumentStorage
+{
+    Task<StoredUserDocument> UploadAsync(UserDocumentUploadRequest request, CancellationToken cancellationToken);
+    Task DeleteAsync(string storageKey, CancellationToken cancellationToken);
+}
+
+public sealed record UserDocumentUploadRequest(
+    long UserAccountId,
+    string DocumentType,
+    string OriginalFileName,
+    string ContentType,
+    byte[] Content,
+    string ChecksumSha256);
+
+public sealed record StoredUserDocument(string StorageKey);

--- a/services/api/src/Firefly.Signal.Identity.Api/Infrastructure/Storage/InMemoryUserDocumentStorage.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Infrastructure/Storage/InMemoryUserDocumentStorage.cs
@@ -1,0 +1,29 @@
+using System.Collections.Concurrent;
+
+namespace Firefly.Signal.Identity.Infrastructure.Storage;
+
+internal sealed class InMemoryUserDocumentStorage : IUserDocumentStorage
+{
+    private readonly ConcurrentDictionary<string, StoredUserDocumentContent> _documents = new();
+
+    public Task<StoredUserDocument> UploadAsync(UserDocumentUploadRequest request, CancellationToken cancellationToken)
+    {
+        var extension = Path.GetExtension(request.OriginalFileName);
+        var storageKey = $"testing/user-documents/{request.UserAccountId}/{Guid.NewGuid():N}{extension}";
+
+        _documents[storageKey] = new StoredUserDocumentContent(
+            request.ContentType,
+            request.ChecksumSha256,
+            request.Content.ToArray());
+
+        return Task.FromResult(new StoredUserDocument(storageKey));
+    }
+
+    public Task DeleteAsync(string storageKey, CancellationToken cancellationToken)
+    {
+        _documents.TryRemove(storageKey, out _);
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed record StoredUserDocumentContent(string ContentType, string ChecksumSha256, byte[] Content);

--- a/services/api/src/Firefly.Signal.Identity.Api/Infrastructure/Storage/S3UserDocumentStorage.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Infrastructure/Storage/S3UserDocumentStorage.cs
@@ -1,0 +1,119 @@
+using Amazon;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.Runtime;
+using Microsoft.Extensions.Options;
+
+namespace Firefly.Signal.Identity.Infrastructure.Storage;
+
+internal sealed class S3UserDocumentStorage(IAmazonS3 s3Client, IOptions<UserDocumentStorageOptions> options) : IUserDocumentStorage
+{
+    private readonly IAmazonS3 _s3Client = s3Client;
+    private readonly UserDocumentStorageOptions _options = options.Value;
+
+    public async Task<StoredUserDocument> UploadAsync(UserDocumentUploadRequest request, CancellationToken cancellationToken)
+    {
+        var extension = Path.GetExtension(request.OriginalFileName);
+        var storageKey = BuildStorageKey(request.UserAccountId, request.DocumentType, extension);
+
+        await using var stream = new MemoryStream(request.Content, writable: false);
+        var putRequest = new PutObjectRequest
+        {
+            BucketName = _options.BucketName,
+            Key = storageKey,
+            InputStream = stream,
+            ContentType = request.ContentType,
+            AutoCloseStream = false,
+            AutoResetStreamPosition = false,
+            ServerSideEncryptionMethod = ServerSideEncryptionMethod.AES256
+        };
+
+        putRequest.Metadata["checksum-sha256"] = request.ChecksumSha256;
+        putRequest.Metadata["document-type"] = request.DocumentType;
+
+        await _s3Client.PutObjectAsync(putRequest, cancellationToken);
+        return new StoredUserDocument(storageKey);
+    }
+
+    public async Task DeleteAsync(string storageKey, CancellationToken cancellationToken)
+    {
+        await _s3Client.DeleteObjectAsync(_options.BucketName, storageKey, cancellationToken);
+    }
+
+    private string BuildStorageKey(long userAccountId, string documentType, string extension)
+    {
+        var prefix = (_options.KeyPrefix ?? string.Empty).Trim().Trim('/');
+        var keyRoot = string.IsNullOrWhiteSpace(prefix)
+            ? $"users/{userAccountId}/{documentType}"
+            : $"{prefix}/users/{userAccountId}/{documentType}";
+
+        return $"{keyRoot}/{Guid.NewGuid():N}{extension.ToLowerInvariant()}";
+    }
+}
+
+public sealed class UserDocumentStorageOptions
+{
+    public const string SectionName = "UserDocumentStorage";
+
+    public string BucketName { get; init; } = string.Empty;
+    public string Region { get; init; } = "eu-west-2";
+    public string? KeyPrefix { get; init; }
+    public string? ServiceUrl { get; init; }
+    public bool UsePathStyle { get; init; }
+    public string? AccessKeyId { get; init; }
+    public string? SecretAccessKey { get; init; }
+    public string? SessionToken { get; init; }
+    public long MaxFileSizeBytes { get; init; } = 10 * 1024 * 1024;
+    public string[] AllowedContentTypes { get; init; } = [];
+    public string[] AllowedFileExtensions { get; init; } = [];
+}
+
+internal static class UserDocumentStorageServiceCollectionExtensions
+{
+    public static IServiceCollection AddUserDocumentStorage(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment environment)
+    {
+        services.Configure<UserDocumentStorageOptions>(configuration.GetSection(UserDocumentStorageOptions.SectionName));
+
+        if (environment.IsEnvironment("Testing"))
+        {
+            services.AddSingleton<IUserDocumentStorage, InMemoryUserDocumentStorage>();
+            return services;
+        }
+
+        services.AddSingleton<IAmazonS3>(serviceProvider =>
+        {
+            var options = serviceProvider.GetRequiredService<IOptions<UserDocumentStorageOptions>>().Value;
+            var config = new AmazonS3Config
+            {
+                ForcePathStyle = options.UsePathStyle
+            };
+
+            if (!string.IsNullOrWhiteSpace(options.ServiceUrl))
+            {
+                config.ServiceURL = options.ServiceUrl;
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.Region))
+            {
+                config.RegionEndpoint = RegionEndpoint.GetBySystemName(options.Region);
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.AccessKeyId) && !string.IsNullOrWhiteSpace(options.SecretAccessKey))
+            {
+                AWSCredentials credentials = string.IsNullOrWhiteSpace(options.SessionToken)
+                    ? new BasicAWSCredentials(options.AccessKeyId, options.SecretAccessKey)
+                    : new SessionAWSCredentials(options.AccessKeyId, options.SecretAccessKey, options.SessionToken);
+
+                return new AmazonS3Client(credentials, config);
+            }
+
+            return new AmazonS3Client(config);
+        });
+
+        services.AddSingleton<IUserDocumentStorage, S3UserDocumentStorage>();
+        return services;
+    }
+}

--- a/services/api/src/Firefly.Signal.Identity.Api/Program.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Program.cs
@@ -3,6 +3,7 @@ using Firefly.Signal.Identity.Domain;
 using Firefly.Signal.Identity.Endpoints;
 using Firefly.Signal.Identity.Infrastructure.Persistence;
 using Firefly.Signal.Identity.Infrastructure.Services;
+using Firefly.Signal.Identity.Infrastructure.Storage;
 using Firefly.Signal.ServiceDefaults;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
@@ -16,6 +17,7 @@ builder.AddFireflyServiceDefaults();
 builder.AddDefaultOpenApi();
 builder.Services.AddProblemDetails();
 builder.Services.Configure<JwtOptions>(builder.Configuration.GetSection("Jwt"));
+builder.Services.AddUserDocumentStorage(builder.Configuration, builder.Environment);
 builder.Services.AddDbContext<IdentityDbContext>(options =>
 {
     if (builder.Environment.IsEnvironment("Testing"))
@@ -65,6 +67,7 @@ app.MapGet("/", () => Results.Ok(new
 
 app.MapAuthEndpoints();
 app.MapUserEndpoints();
+app.MapUserDocumentEndpoints();
 
 app.UseDefaultOpenApi();
 app.Run();

--- a/services/api/src/Firefly.Signal.Identity.Api/appsettings.json
+++ b/services/api/src/Firefly.Signal.Identity.Api/appsettings.json
@@ -8,6 +8,28 @@
     "SigningKey": "firefly-signal-dev-signing-key-please-change",
     "ExpiresInMinutes": 120
   },
+  "UserDocumentStorage": {
+    "BucketName": "firefly-signal-documents-dev",
+    "Region": "eu-west-2",
+    "KeyPrefix": "identity/user-documents",
+    "MaxFileSizeBytes": 10485760,
+    "AllowedContentTypes": [
+      "application/pdf",
+      "application/msword",
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "application/rtf",
+      "application/vnd.oasis.opendocument.text",
+      "text/plain"
+    ],
+    "AllowedFileExtensions": [
+      ".pdf",
+      ".doc",
+      ".docx",
+      ".rtf",
+      ".odt",
+      ".txt"
+    ]
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/services/api/tests/Firefly.Signal.Identity.FunctionalTests/UserDocumentEndpointsTests.cs
+++ b/services/api/tests/Firefly.Signal.Identity.FunctionalTests/UserDocumentEndpointsTests.cs
@@ -1,0 +1,196 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Firefly.Signal.Identity.Application;
+using Firefly.Signal.Identity.Domain;
+using Firefly.Signal.Identity.Infrastructure.Persistence;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Firefly.Signal.Identity.FunctionalTests;
+
+[TestClass]
+public class UserDocumentEndpointsTests
+{
+    [TestMethod]
+    public async Task Upload_creates_document_metadata_and_lists_it_for_current_user()
+    {
+        await using var factory = CreateFactory();
+        SeedIdentityData(factory.Services);
+        using var client = factory.CreateClient();
+        var login = await LoginAsAdminAsync(client);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", login.AccessToken);
+
+        using var uploadContent = CreateUploadContent(
+            documentType: "cv",
+            fileName: "firefly-cv.pdf",
+            contentType: "application/pdf",
+            fileBytes: "sample-cv-pdf-content"u8.ToArray(),
+            displayName: "Primary CV");
+
+        var uploadResponse = await client.PostAsync("/api/documents", uploadContent);
+        uploadResponse.EnsureSuccessStatusCode();
+
+        var createdDocument = await uploadResponse.Content.ReadFromJsonAsync<UserDocumentResponse>();
+        Assert.IsNotNull(createdDocument);
+        Assert.AreEqual("cv", createdDocument.DocumentType);
+        Assert.AreEqual("Primary CV", createdDocument.DisplayName);
+        Assert.IsTrue(createdDocument.IsDefault);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(createdDocument.StorageKey));
+        Assert.AreEqual("application/pdf", createdDocument.ContentType);
+
+        var listResponse = await client.GetAsync("/api/documents");
+        listResponse.EnsureSuccessStatusCode();
+
+        var documents = await listResponse.Content.ReadFromJsonAsync<List<UserDocumentResponse>>();
+        Assert.IsNotNull(documents);
+        Assert.HasCount(1, documents);
+        Assert.AreEqual(createdDocument.Id, documents[0].Id);
+    }
+
+    [TestMethod]
+    public async Task Set_default_switches_default_cv_document()
+    {
+        await using var factory = CreateFactory();
+        SeedIdentityData(factory.Services);
+        using var client = factory.CreateClient();
+        var login = await LoginAsAdminAsync(client);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", login.AccessToken);
+
+        var firstDocument = await UploadDocumentAsync(client, "cv", "first-cv.pdf", "application/pdf", "first"u8.ToArray(), "First CV");
+        var secondDocument = await UploadDocumentAsync(client, "cv", "second-cv.pdf", "application/pdf", "second"u8.ToArray(), "Second CV");
+
+        var setDefaultResponse = await client.PostAsync($"/api/documents/{secondDocument.Id}/default", content: null);
+        setDefaultResponse.EnsureSuccessStatusCode();
+
+        var updatedDocument = await setDefaultResponse.Content.ReadFromJsonAsync<UserDocumentResponse>();
+        Assert.IsNotNull(updatedDocument);
+        Assert.AreEqual(secondDocument.Id, updatedDocument.Id);
+        Assert.IsTrue(updatedDocument.IsDefault);
+
+        var documents = await client.GetFromJsonAsync<List<UserDocumentResponse>>("/api/documents");
+        Assert.IsNotNull(documents);
+        Assert.HasCount(2, documents);
+        Assert.AreEqual(secondDocument.Id, documents.Single(x => x.IsDefault).Id);
+        Assert.IsFalse(documents.Single(x => x.Id == firstDocument.Id).IsDefault);
+    }
+
+    [TestMethod]
+    public async Task Delete_removes_document_from_active_list_and_promotes_replacement_default()
+    {
+        await using var factory = CreateFactory();
+        SeedIdentityData(factory.Services);
+        using var client = factory.CreateClient();
+        var login = await LoginAsAdminAsync(client);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", login.AccessToken);
+
+        var firstDocument = await UploadDocumentAsync(client, "cv", "first-cv.pdf", "application/pdf", "first"u8.ToArray(), "First CV");
+        var secondDocument = await UploadDocumentAsync(client, "cv", "second-cv.pdf", "application/pdf", "second"u8.ToArray(), "Second CV");
+
+        var deleteResponse = await client.DeleteAsync($"/api/documents/{firstDocument.Id}");
+        Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        var documents = await client.GetFromJsonAsync<List<UserDocumentResponse>>("/api/documents");
+        Assert.IsNotNull(documents);
+        Assert.HasCount(1, documents);
+        Assert.AreEqual(secondDocument.Id, documents[0].Id);
+        Assert.IsTrue(documents[0].IsDefault);
+    }
+
+    [TestMethod]
+    public async Task Upload_rejects_unsupported_content_type()
+    {
+        await using var factory = CreateFactory();
+        SeedIdentityData(factory.Services);
+        using var client = factory.CreateClient();
+        var login = await LoginAsAdminAsync(client);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", login.AccessToken);
+
+        using var uploadContent = CreateUploadContent(
+            documentType: "cv",
+            fileName: "firefly-cv.exe",
+            contentType: "application/octet-stream",
+            fileBytes: [1, 2, 3, 4],
+            displayName: "Unsafe CV");
+
+        var uploadResponse = await client.PostAsync("/api/documents", uploadContent);
+
+        Assert.AreEqual(HttpStatusCode.BadRequest, uploadResponse.StatusCode);
+    }
+
+    private static WebApplicationFactory<Firefly.Signal.Identity.Api.Program> CreateFactory()
+    {
+        var databaseName = $"identity-documents-tests-{Guid.NewGuid():N}";
+
+        return new WebApplicationFactory<Firefly.Signal.Identity.Api.Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Testing");
+                builder.UseSetting("Testing:DatabaseName", databaseName);
+            });
+    }
+
+    private static async Task<LoginResponse> LoginAsAdminAsync(HttpClient client)
+    {
+        var response = await client.PostAsJsonAsync("/api/auth/login", new LoginUserRequest("admin", "Admin123!"));
+        response.EnsureSuccessStatusCode();
+
+        var login = await response.Content.ReadFromJsonAsync<LoginResponse>();
+        Assert.IsNotNull(login);
+        return login;
+    }
+
+    private static async Task<UserDocumentResponse> UploadDocumentAsync(
+        HttpClient client,
+        string documentType,
+        string fileName,
+        string contentType,
+        byte[] fileBytes,
+        string displayName)
+    {
+        using var uploadContent = CreateUploadContent(documentType, fileName, contentType, fileBytes, displayName);
+        var response = await client.PostAsync("/api/documents", uploadContent);
+        response.EnsureSuccessStatusCode();
+
+        var document = await response.Content.ReadFromJsonAsync<UserDocumentResponse>();
+        Assert.IsNotNull(document);
+        return document;
+    }
+
+    private static MultipartFormDataContent CreateUploadContent(
+        string documentType,
+        string fileName,
+        string contentType,
+        byte[] fileBytes,
+        string displayName)
+    {
+        var content = new MultipartFormDataContent();
+        content.Add(new StringContent(documentType), "DocumentType");
+        content.Add(new StringContent(displayName), "DisplayName");
+
+        var fileContent = new ByteArrayContent(fileBytes);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+        content.Add(fileContent, "File", fileName);
+        return content;
+    }
+
+    private static void SeedIdentityData(IServiceProvider services)
+    {
+        using var scope = services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<IdentityDbContext>();
+        var passwordHasher = scope.ServiceProvider.GetRequiredService<IPasswordHasher<UserAccount>>();
+
+        if (dbContext.Users.Any())
+        {
+            return;
+        }
+
+        var admin = UserAccount.Create("admin", string.Empty, "admin@firefly.local", "Firefly Admin", Roles.Admin);
+        admin.ChangePassword(passwordHasher.HashPassword(admin, "Admin123!"));
+
+        dbContext.Users.Add(admin);
+        dbContext.SaveChanges();
+    }
+}


### PR DESCRIPTION
Closes #42

## Summary
- add authenticated Identity API endpoints for user document upload, listing, default selection, and delete
- store document binaries in Amazon S3 while keeping metadata in PostgreSQL
- update production deployment wiring for S3 secrets and align docs with the S3 storage decision

## Validation
- dotnet test services/api/tests/Firefly.Signal.Identity.FunctionalTests/Firefly.Signal.Identity.FunctionalTests.csproj
- dotnet build services/api/Firefly.Signal.Api.slnx
- dotnet build services/api/src/Firefly.Signal.Identity.Api/Firefly.Signal.Identity.Api.csproj