### PR TITLE
feat(profile): add current-user profile management (#39)

### DIFF
--- a/apps/web/src/api/profile/profile.api.ts
+++ b/apps/web/src/api/profile/profile.api.ts
@@ -1,0 +1,12 @@
+import { getJson, putJson } from "@/lib/http/client";
+import type { UserProfileRequestDto, UserProfileResponseDto } from "@/api/profile/profile.types";
+
+export async function getCurrentProfile(): Promise<UserProfileResponseDto> {
+  return getJson<UserProfileResponseDto>("/api/users/profile");
+}
+
+export async function upsertCurrentProfile(
+  input: UserProfileRequestDto
+): Promise<UserProfileResponseDto> {
+  return putJson<UserProfileResponseDto, UserProfileRequestDto>("/api/users/profile", input);
+}

--- a/apps/web/src/api/profile/profile.types.ts
+++ b/apps/web/src/api/profile/profile.types.ts
@@ -1,0 +1,29 @@
+export type UserProfileRequestDto = {
+  fullName: string | null;
+  preferredTitle: string | null;
+  primaryLocationPostcode: string | null;
+  linkedInUrl: string | null;
+  githubUrl: string | null;
+  portfolioUrl: string | null;
+  summary: string | null;
+  skillsText: string | null;
+  experienceText: string | null;
+  preferencesJson: string | null;
+};
+
+export type UserProfileResponseDto = {
+  id: number;
+  userAccountId: number;
+  fullName: string | null;
+  preferredTitle: string | null;
+  primaryLocationPostcode: string | null;
+  linkedInUrl: string | null;
+  githubUrl: string | null;
+  portfolioUrl: string | null;
+  summary: string | null;
+  skillsText: string | null;
+  experienceText: string | null;
+  preferencesJson: string;
+  createdAtUtc: string;
+  updatedAtUtc: string;
+};

--- a/apps/web/src/app/AppRouter.tsx
+++ b/apps/web/src/app/AppRouter.tsx
@@ -40,6 +40,11 @@ const AppJobDetailPage = lazy(() =>
     default: module.AppJobDetailPage
   }))
 );
+const AppProfilePage = lazy(() =>
+  import("@/routes/AppProfilePage").then((module) => ({
+    default: module.AppProfilePage
+  }))
+);
 
 function withRouteFallback(page: React.ReactNode) {
   return <Suspense fallback={<RouteLoadingScreen />}>{page}</Suspense>;
@@ -67,6 +72,14 @@ const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         {withRouteFallback(<AppHomePage />)}
+      </ProtectedRoute>
+    )
+  },
+  {
+    path: "/app/profile",
+    element: (
+      <ProtectedRoute>
+        {withRouteFallback(<AppProfilePage />)}
       </ProtectedRoute>
     )
   },

--- a/apps/web/src/components/AppHeader.test.tsx
+++ b/apps/web/src/components/AppHeader.test.tsx
@@ -37,4 +37,33 @@ describe("AppHeader", () => {
     expect(screen.getByRole("button", { name: "Sign out" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Workspace" })).toBeInTheDocument();
   });
+
+  it("keeps the workspace link inactive when the profile route is active", () => {
+    useSessionStore.setState({
+      user: {
+        userAccount: "admin",
+        displayName: "Admin",
+        role: "admin",
+        email: "admin@example.com"
+      },
+      isAuthenticated: true
+    });
+
+    render(
+      <ThemeProvider theme={theme}>
+        <MemoryRouter initialEntries={["/app/profile"]}>
+          <AppHeader variant="authenticated" />
+        </MemoryRouter>
+      </ThemeProvider>
+    );
+
+    expect(screen.getByRole("link", { name: "Profile" })).toHaveClass(
+      "bg-accent-secondary",
+      "text-accent-secondary-foreground"
+    );
+    expect(screen.getByRole("link", { name: "Workspace" })).not.toHaveClass(
+      "bg-accent-secondary",
+      "text-accent-secondary-foreground"
+    );
+  });
 });

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -2,6 +2,7 @@ import AutoAwesomeRoundedIcon from "@mui/icons-material/AutoAwesomeRounded";
 import DashboardRoundedIcon from "@mui/icons-material/DashboardRounded";
 import LoginRoundedIcon from "@mui/icons-material/LoginRounded";
 import LogoutRoundedIcon from "@mui/icons-material/LogoutRounded";
+import PersonRoundedIcon from "@mui/icons-material/PersonRounded";
 import SearchRoundedIcon from "@mui/icons-material/SearchRounded";
 import VisibilityRoundedIcon from "@mui/icons-material/VisibilityRounded";
 import WorkOutlineRoundedIcon from "@mui/icons-material/WorkOutlineRounded";
@@ -15,14 +16,22 @@ type AppHeaderProps = {
   actions?: ReactNode;
 };
 
-const publicLinks = [
-  { to: "/", label: "Discover", icon: <SearchRoundedIcon fontSize="inherit" /> },
-  { to: "/search", label: "Search", icon: <VisibilityRoundedIcon fontSize="inherit" /> }
+type NavigationLink = {
+  to: string;
+  label: string;
+  icon: ReactNode;
+  end?: boolean;
+};
+
+const publicLinks: NavigationLink[] = [
+  { to: "/", label: "Discover", icon: <SearchRoundedIcon fontSize="inherit" />, end: true },
+  { to: "/search", label: "Search", icon: <VisibilityRoundedIcon fontSize="inherit" />, end: true }
 ];
 
-const authenticatedLinks = [
+const authenticatedLinks: NavigationLink[] = [
   ...publicLinks,
-  { to: "/app", label: "Workspace", icon: <DashboardRoundedIcon fontSize="inherit" /> },
+  { to: "/app", label: "Workspace", icon: <DashboardRoundedIcon fontSize="inherit" />, end: true },
+  { to: "/app/profile", label: "Profile", icon: <PersonRoundedIcon fontSize="inherit" />, end: true },
   { to: "/admin/manage-jobs", label: "Manage jobs", icon: <WorkOutlineRoundedIcon fontSize="inherit" /> }
 ];
 
@@ -58,6 +67,7 @@ export function AppHeader({ variant = "public", actions }: AppHeaderProps) {
             <NavLink
               key={link.to}
               to={link.to}
+              end={link.end}
               className={({ isActive }) =>
                 `inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors ${
                   isActive

--- a/apps/web/src/features/profile/views/ProfileView.test.tsx
+++ b/apps/web/src/features/profile/views/ProfileView.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { theme } from "@/app/theme";
+import { getCurrentProfile, upsertCurrentProfile } from "@/api/profile/profile.api";
+import { ProfileView } from "@/features/profile/views/ProfileView";
+import { ApiError } from "@/lib/http/api-error";
+import { useSessionStore } from "@/store/session.store";
+
+vi.mock("@/api/profile/profile.api", () => ({
+  getCurrentProfile: vi.fn(),
+  upsertCurrentProfile: vi.fn()
+}));
+
+describe("ProfileView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSessionStore.setState({
+      user: {
+        userAccount: "admin",
+        displayName: "Admin",
+        role: "admin",
+        email: "admin@example.com"
+      },
+      isAuthenticated: true
+    });
+  });
+
+  it("loads the current profile and saves edits", async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(getCurrentProfile).mockResolvedValueOnce({
+      id: 1,
+      userAccountId: 1,
+      fullName: "Ada Lovelace",
+      preferredTitle: "Senior Developer",
+      primaryLocationPostcode: "SW1A 1AA",
+      linkedInUrl: "https://linkedin.com/in/ada",
+      githubUrl: "https://github.com/ada",
+      portfolioUrl: "https://ada.dev",
+      summary: "Original summary",
+      skillsText: "C#, .NET",
+      experienceText: "Original experience",
+      preferencesJson: "{}",
+      createdAtUtc: "2026-04-11T10:00:00Z",
+      updatedAtUtc: "2026-04-11T10:00:00Z"
+    });
+
+    vi.mocked(upsertCurrentProfile).mockResolvedValueOnce({
+      id: 1,
+      userAccountId: 1,
+      fullName: "Ada Lovelace",
+      preferredTitle: "Principal Engineer",
+      primaryLocationPostcode: "EC1A 1BB",
+      linkedInUrl: "https://linkedin.com/in/ada",
+      githubUrl: "https://github.com/ada",
+      portfolioUrl: "https://ada.dev",
+      summary: "Updated summary",
+      skillsText: "C#, .NET, Azure",
+      experienceText: "Updated experience",
+      preferencesJson: "{\"preferredJobTypes\":[\"backend\"]}",
+      createdAtUtc: "2026-04-11T10:00:00Z",
+      updatedAtUtc: "2026-04-11T11:00:00Z"
+    });
+
+    render(
+      <ThemeProvider theme={theme}>
+        <MemoryRouter initialEntries={["/app/profile"]}>
+          <ProfileView />
+        </MemoryRouter>
+      </ThemeProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Ada Lovelace")).toBeInTheDocument();
+    });
+
+    await user.clear(screen.getByLabelText("Preferred title"));
+    await user.type(screen.getByLabelText("Preferred title"), "Principal Engineer");
+    await user.clear(screen.getByLabelText("Primary UK postcode"));
+    await user.type(screen.getByLabelText("Primary UK postcode"), "ec1a 1bb");
+    await user.click(screen.getByRole("button", { name: "Save profile" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Profile saved.")).toBeInTheDocument();
+    });
+
+    expect(upsertCurrentProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preferredTitle: "Principal Engineer",
+        primaryLocationPostcode: "ec1a 1bb"
+      })
+    );
+    expect(screen.getByDisplayValue("EC1A 1BB")).toBeInTheDocument();
+  }, 10000);
+
+  it("shows a retry state when profile loading fails", async () => {
+    vi.mocked(getCurrentProfile).mockRejectedValueOnce(new ApiError("Server unavailable", 500));
+
+    render(
+      <ThemeProvider theme={theme}>
+        <MemoryRouter initialEntries={["/app/profile"]}>
+          <ProfileView />
+        </MemoryRouter>
+      </ThemeProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("We couldn't load your profile right now.")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/profile/views/ProfileView.tsx
+++ b/apps/web/src/features/profile/views/ProfileView.tsx
@@ -1,0 +1,294 @@
+import SaveRoundedIcon from "@mui/icons-material/SaveRounded";
+import { Alert, Box, Button, CircularProgress, Stack, TextField } from "@mui/material";
+import type { FormEvent } from "react";
+import { useEffect, useState } from "react";
+import { AppHeader } from "@/components/AppHeader";
+import { SectionCard } from "@/components/SectionCard";
+import { getCurrentProfile, upsertCurrentProfile } from "@/api/profile/profile.api";
+import type { UserProfileRequestDto, UserProfileResponseDto } from "@/api/profile/profile.types";
+import { ApiError } from "@/lib/http/api-error";
+
+type ProfileFormState = {
+  fullName: string;
+  preferredTitle: string;
+  primaryLocationPostcode: string;
+  linkedInUrl: string;
+  githubUrl: string;
+  portfolioUrl: string;
+  summary: string;
+  skillsText: string;
+  experienceText: string;
+  preferencesJson: string;
+};
+
+const emptyProfileFormState: ProfileFormState = {
+  fullName: "",
+  preferredTitle: "",
+  primaryLocationPostcode: "",
+  linkedInUrl: "",
+  githubUrl: "",
+  portfolioUrl: "",
+  summary: "",
+  skillsText: "",
+  experienceText: "",
+  preferencesJson: "{}"
+};
+
+function mapProfileToFormState(profile: UserProfileResponseDto): ProfileFormState {
+  return {
+    fullName: profile.fullName ?? "",
+    preferredTitle: profile.preferredTitle ?? "",
+    primaryLocationPostcode: profile.primaryLocationPostcode ?? "",
+    linkedInUrl: profile.linkedInUrl ?? "",
+    githubUrl: profile.githubUrl ?? "",
+    portfolioUrl: profile.portfolioUrl ?? "",
+    summary: profile.summary ?? "",
+    skillsText: profile.skillsText ?? "",
+    experienceText: profile.experienceText ?? "",
+    preferencesJson: profile.preferencesJson || "{}"
+  };
+}
+
+function mapFormStateToRequest(input: ProfileFormState): UserProfileRequestDto {
+  const normalize = (value: string) => {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+  };
+
+  return {
+    fullName: normalize(input.fullName),
+    preferredTitle: normalize(input.preferredTitle),
+    primaryLocationPostcode: normalize(input.primaryLocationPostcode),
+    linkedInUrl: normalize(input.linkedInUrl),
+    githubUrl: normalize(input.githubUrl),
+    portfolioUrl: normalize(input.portfolioUrl),
+    summary: normalize(input.summary),
+    skillsText: normalize(input.skillsText),
+    experienceText: normalize(input.experienceText),
+    preferencesJson: normalize(input.preferencesJson) ?? "{}"
+  };
+}
+
+export function ProfileView() {
+  const [formState, setFormState] = useState<ProfileFormState>(emptyProfileFormState);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isEmptyProfile, setIsEmptyProfile] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadProfile() {
+      setIsLoading(true);
+      setLoadError(null);
+      setSaveMessage(null);
+
+      try {
+        const profile = await getCurrentProfile();
+
+        if (cancelled) {
+          return;
+        }
+
+        setFormState(mapProfileToFormState(profile));
+        setIsEmptyProfile(false);
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+
+        if (error instanceof ApiError && error.status === 404) {
+          setFormState(emptyProfileFormState);
+          setIsEmptyProfile(true);
+        } else {
+          setLoadError("We couldn't load your profile right now.");
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void loadProfile();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    void (async () => {
+      setIsSaving(true);
+      setSaveError(null);
+      setSaveMessage(null);
+
+      try {
+        const savedProfile = await upsertCurrentProfile(mapFormStateToRequest(formState));
+        setFormState(mapProfileToFormState(savedProfile));
+        setIsEmptyProfile(false);
+        setSaveMessage("Profile saved.");
+      } catch {
+        setSaveError("We couldn't save your profile right now.");
+      } finally {
+        setIsSaving(false);
+      }
+    })();
+  }
+
+  function updateField<Key extends keyof ProfileFormState>(key: Key, value: ProfileFormState[Key]) {
+    setFormState((current) => ({
+      ...current,
+      [key]: value
+    }));
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <AppHeader variant="authenticated" />
+
+      <div className="mx-auto max-w-5xl px-5 py-8 sm:px-8">
+        <SectionCard className="p-6 sm:p-8">
+          <div className="max-w-3xl">
+            <h1 className="font-serif text-3xl font-semibold text-foreground">Your profile</h1>
+            <p className="mt-3 text-sm leading-7 text-foreground-secondary">
+              Keep your stored personal context up to date so job search, saved applications, and
+              later AI assistance can use the right details.
+            </p>
+          </div>
+        </SectionCard>
+
+        <SectionCard className="mt-6 p-6 sm:p-8">
+          {isLoading ? (
+            <Box className="flex min-h-56 items-center justify-center">
+              <CircularProgress aria-label="Loading profile" />
+            </Box>
+          ) : loadError ? (
+            <Stack spacing={2}>
+              <Alert severity="error">{loadError}</Alert>
+              <div>
+                <Button variant="outlined" onClick={() => setReloadKey((current) => current + 1)}>
+                  Retry
+                </Button>
+              </div>
+            </Stack>
+          ) : (
+            <form onSubmit={handleSubmit}>
+              <Stack spacing={3}>
+                {isEmptyProfile ? (
+                  <Alert severity="info">
+                    No profile has been saved yet. Fill in what matters most and save when you are ready.
+                  </Alert>
+                ) : null}
+                {saveError ? <Alert severity="error">{saveError}</Alert> : null}
+                {saveMessage ? <Alert severity="success">{saveMessage}</Alert> : null}
+
+                <Stack direction={{ xs: "column", md: "row" }} spacing={2}>
+                  <TextField
+                    fullWidth
+                    label="Full name"
+                    value={formState.fullName}
+                    onChange={(event) => updateField("fullName", event.target.value)}
+                  />
+                  <TextField
+                    fullWidth
+                    label="Preferred title"
+                    value={formState.preferredTitle}
+                    onChange={(event) => updateField("preferredTitle", event.target.value)}
+                  />
+                </Stack>
+
+                <TextField
+                  label="Primary UK postcode"
+                  value={formState.primaryLocationPostcode}
+                  onChange={(event) => updateField("primaryLocationPostcode", event.target.value)}
+                  helperText="Used as your default location anchor for future distance-based search."
+                />
+
+                <Stack direction={{ xs: "column", md: "row" }} spacing={2}>
+                  <TextField
+                    fullWidth
+                    label="LinkedIn URL"
+                    value={formState.linkedInUrl}
+                    onChange={(event) => updateField("linkedInUrl", event.target.value)}
+                  />
+                  <TextField
+                    fullWidth
+                    label="GitHub URL"
+                    value={formState.githubUrl}
+                    onChange={(event) => updateField("githubUrl", event.target.value)}
+                  />
+                </Stack>
+
+                <TextField
+                  fullWidth
+                  label="Portfolio URL"
+                  value={formState.portfolioUrl}
+                  onChange={(event) => updateField("portfolioUrl", event.target.value)}
+                />
+
+                <TextField
+                  fullWidth
+                  multiline
+                  minRows={4}
+                  label="Summary"
+                  value={formState.summary}
+                  onChange={(event) => updateField("summary", event.target.value)}
+                />
+
+                <TextField
+                  fullWidth
+                  multiline
+                  minRows={4}
+                  label="Skills"
+                  value={formState.skillsText}
+                  onChange={(event) => updateField("skillsText", event.target.value)}
+                />
+
+                <TextField
+                  fullWidth
+                  multiline
+                  minRows={5}
+                  label="Experience"
+                  value={formState.experienceText}
+                  onChange={(event) => updateField("experienceText", event.target.value)}
+                />
+
+                <TextField
+                  fullWidth
+                  multiline
+                  minRows={3}
+                  label="Preferences JSON"
+                  value={formState.preferencesJson}
+                  onChange={(event) => updateField("preferencesJson", event.target.value)}
+                  helperText="Keep this light for now. JSON is stored as-is for MVP flexibility."
+                />
+
+                <div>
+                  <Button
+                    type="submit"
+                    variant="contained"
+                    startIcon={<SaveRoundedIcon />}
+                    disabled={isSaving}
+                    sx={{
+                      bgcolor: "accent.main",
+                      "&:hover": { bgcolor: "accent.dark" }
+                    }}
+                  >
+                    {isSaving ? "Saving..." : "Save profile"}
+                  </Button>
+                </div>
+              </Stack>
+            </form>
+          )}
+        </SectionCard>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/AppProfilePage.tsx
+++ b/apps/web/src/routes/AppProfilePage.tsx
@@ -1,0 +1,5 @@
+import { ProfileView } from "@/features/profile/views/ProfileView";
+
+export function AppProfilePage() {
+  return <ProfileView />;
+}

--- a/docs/backend-designs.md
+++ b/docs/backend-designs.md
@@ -139,6 +139,7 @@ Do not force async workflows into the first implementation if synchronous reques
 
 ## API Design Guidance
 - Version public APIs from the start, even if only `v1`.
+- Keep gateway-facing route shapes grouped by downstream API area, for example `/api/auth/...`, `/api/users/...`, `/api/job-search/...`, and `/api/ai/...`.
 - Return stable result models for job cards, job detail, workflow lists, user profile data, and AI outputs.
 - Normalize provider-specific quirks before they reach the frontend.
 - Keep search, workflow, profile, and AI contracts explicit and typed.

--- a/docs/backend-designs/identity-api-direction.md
+++ b/docs/backend-designs/identity-api-direction.md
@@ -20,12 +20,17 @@ Do not build or copy a full identity-server-style platform.
 - return current-user information to the frontend
 
 ## Recommended Route Shape
+- Keep identity routes under the gateway-forwarded groups:
 - `POST /api/auth/google/start`
 - `GET /api/auth/google/callback`
 - `POST /api/auth/logout`
 - `GET /api/auth/me`
+- `GET /api/users/profile`
+- `PUT /api/users/profile`
+- `GET /api/users/documents`
+- `POST /api/users/documents`
 
-The exact route names can change, but keep the surface small.
+The exact route names can change, but keep the surface small and aligned with the gateway route groups.
 
 ## Recommended Project Shape
 

--- a/services/api/src/Firefly.Signal.Identity.Api/Application/UserProfileContracts.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Application/UserProfileContracts.cs
@@ -1,0 +1,51 @@
+using Firefly.Signal.Identity.Domain;
+
+namespace Firefly.Signal.Identity.Application;
+
+public sealed record UserProfileRequest(
+    string? FullName,
+    string? PreferredTitle,
+    string? PrimaryLocationPostcode,
+    string? LinkedInUrl,
+    string? GithubUrl,
+    string? PortfolioUrl,
+    string? Summary,
+    string? SkillsText,
+    string? ExperienceText,
+    string? PreferencesJson);
+
+public sealed record UserProfileResponse(
+    long Id,
+    long UserAccountId,
+    string? FullName,
+    string? PreferredTitle,
+    string? PrimaryLocationPostcode,
+    string? LinkedInUrl,
+    string? GithubUrl,
+    string? PortfolioUrl,
+    string? Summary,
+    string? SkillsText,
+    string? ExperienceText,
+    string PreferencesJson,
+    DateTime CreatedAtUtc,
+    DateTime UpdatedAtUtc);
+
+public static class UserProfileContractMappings
+{
+    public static UserProfileResponse ToResponse(this UserProfile profile)
+        => new(
+            profile.Id,
+            profile.UserAccountId,
+            profile.FullName,
+            profile.PreferredTitle,
+            profile.PrimaryLocationPostcode,
+            profile.LinkedInUrl,
+            profile.GithubUrl,
+            profile.PortfolioUrl,
+            profile.Summary,
+            profile.SkillsText,
+            profile.ExperienceText,
+            profile.PreferencesJson,
+            profile.CreatedAtUtc,
+            profile.UpdatedAtUtc);
+}

--- a/services/api/src/Firefly.Signal.Identity.Api/Endpoints/UserDocumentEndpoints.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Endpoints/UserDocumentEndpoints.cs
@@ -15,7 +15,7 @@ public static class UserDocumentEndpoints
 {
     public static IEndpointRouteBuilder MapUserDocumentEndpoints(this IEndpointRouteBuilder endpoints)
     {
-        var group = endpoints.MapGroup("/api/documents").RequireAuthorization();
+        var group = endpoints.MapGroup("/api/users/documents").RequireAuthorization();
 
         group.MapGet("/", ListAsync);
         group.MapGet("/{id:long}", GetByIdAsync);
@@ -158,7 +158,7 @@ public static class UserDocumentEndpoints
             dbContext.UserDocuments.Add(document);
             await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Results.Created($"/api/documents/{document.Id}", document.ToResponse());
+            return Results.Created($"/api/users/documents/{document.Id}", document.ToResponse());
         }
         catch
         {

--- a/services/api/src/Firefly.Signal.Identity.Api/Endpoints/UserProfileEndpoints.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Endpoints/UserProfileEndpoints.cs
@@ -1,0 +1,103 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Firefly.Signal.Identity.Application;
+using Firefly.Signal.Identity.Domain;
+using Firefly.Signal.Identity.Infrastructure.Persistence;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Firefly.Signal.Identity.Endpoints;
+
+public static class UserProfileEndpoints
+{
+    public static IEndpointRouteBuilder MapUserProfileEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/users/profile").RequireAuthorization();
+
+        group.MapGet("/", GetCurrentAsync);
+        group.MapPut("/", UpsertCurrentAsync);
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> GetCurrentAsync(
+        ClaimsPrincipal claimsPrincipal,
+        IdentityDbContext dbContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = GetCurrentUserId(claimsPrincipal);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var profile = await dbContext.UserProfiles
+            .SingleOrDefaultAsync(x => x.UserAccountId == userId.Value, cancellationToken);
+
+        return profile is null ? Results.NotFound() : Results.Ok(profile.ToResponse());
+    }
+
+    private static async Task<IResult> UpsertCurrentAsync(
+        UserProfileRequest request,
+        ClaimsPrincipal claimsPrincipal,
+        IdentityDbContext dbContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = GetCurrentUserId(claimsPrincipal);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        if (!await dbContext.Users.AnyAsync(x => x.Id == userId.Value, cancellationToken))
+        {
+            return Results.Unauthorized();
+        }
+
+        var profile = await dbContext.UserProfiles
+            .SingleOrDefaultAsync(x => x.UserAccountId == userId.Value, cancellationToken);
+
+        if (profile is null)
+        {
+            profile = UserProfile.Create(
+                userId.Value,
+                request.FullName,
+                request.PreferredTitle,
+                request.PrimaryLocationPostcode,
+                request.LinkedInUrl,
+                request.GithubUrl,
+                request.PortfolioUrl,
+                request.Summary,
+                request.SkillsText,
+                request.ExperienceText,
+                request.PreferencesJson);
+
+            dbContext.UserProfiles.Add(profile);
+            await dbContext.SaveChangesAsync(cancellationToken);
+            return Results.Created("/api/users/profile", profile.ToResponse());
+        }
+
+        profile.Update(
+            request.FullName,
+            request.PreferredTitle,
+            request.PrimaryLocationPostcode,
+            request.LinkedInUrl,
+            request.GithubUrl,
+            request.PortfolioUrl,
+            request.Summary,
+            request.SkillsText,
+            request.ExperienceText,
+            request.PreferencesJson);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return Results.Ok(profile.ToResponse());
+    }
+
+    private static long? GetCurrentUserId(ClaimsPrincipal claimsPrincipal)
+    {
+        var subject = claimsPrincipal.FindFirstValue(JwtRegisteredClaimNames.Sub)
+            ?? claimsPrincipal.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        return long.TryParse(subject, out var userId) ? userId : null;
+    }
+}

--- a/services/api/src/Firefly.Signal.Identity.Api/Program.cs
+++ b/services/api/src/Firefly.Signal.Identity.Api/Program.cs
@@ -66,6 +66,7 @@ app.MapGet("/", () => Results.Ok(new
 }));
 
 app.MapAuthEndpoints();
+app.MapUserProfileEndpoints();
 app.MapUserEndpoints();
 app.MapUserDocumentEndpoints();
 

--- a/services/api/tests/Firefly.Signal.Identity.FunctionalTests/UserDocumentEndpointsTests.cs
+++ b/services/api/tests/Firefly.Signal.Identity.FunctionalTests/UserDocumentEndpointsTests.cs
@@ -30,7 +30,7 @@ public class UserDocumentEndpointsTests
             fileBytes: "sample-cv-pdf-content"u8.ToArray(),
             displayName: "Primary CV");
 
-        var uploadResponse = await client.PostAsync("/api/documents", uploadContent);
+        var uploadResponse = await client.PostAsync("/api/users/documents", uploadContent);
         uploadResponse.EnsureSuccessStatusCode();
 
         var createdDocument = await uploadResponse.Content.ReadFromJsonAsync<UserDocumentResponse>();
@@ -41,7 +41,7 @@ public class UserDocumentEndpointsTests
         Assert.IsFalse(string.IsNullOrWhiteSpace(createdDocument.StorageKey));
         Assert.AreEqual("application/pdf", createdDocument.ContentType);
 
-        var listResponse = await client.GetAsync("/api/documents");
+        var listResponse = await client.GetAsync("/api/users/documents");
         listResponse.EnsureSuccessStatusCode();
 
         var documents = await listResponse.Content.ReadFromJsonAsync<List<UserDocumentResponse>>();
@@ -62,7 +62,7 @@ public class UserDocumentEndpointsTests
         var firstDocument = await UploadDocumentAsync(client, "cv", "first-cv.pdf", "application/pdf", "first"u8.ToArray(), "First CV");
         var secondDocument = await UploadDocumentAsync(client, "cv", "second-cv.pdf", "application/pdf", "second"u8.ToArray(), "Second CV");
 
-        var setDefaultResponse = await client.PostAsync($"/api/documents/{secondDocument.Id}/default", content: null);
+        var setDefaultResponse = await client.PostAsync($"/api/users/documents/{secondDocument.Id}/default", content: null);
         setDefaultResponse.EnsureSuccessStatusCode();
 
         var updatedDocument = await setDefaultResponse.Content.ReadFromJsonAsync<UserDocumentResponse>();
@@ -70,7 +70,7 @@ public class UserDocumentEndpointsTests
         Assert.AreEqual(secondDocument.Id, updatedDocument.Id);
         Assert.IsTrue(updatedDocument.IsDefault);
 
-        var documents = await client.GetFromJsonAsync<List<UserDocumentResponse>>("/api/documents");
+        var documents = await client.GetFromJsonAsync<List<UserDocumentResponse>>("/api/users/documents");
         Assert.IsNotNull(documents);
         Assert.HasCount(2, documents);
         Assert.AreEqual(secondDocument.Id, documents.Single(x => x.IsDefault).Id);
@@ -89,10 +89,10 @@ public class UserDocumentEndpointsTests
         var firstDocument = await UploadDocumentAsync(client, "cv", "first-cv.pdf", "application/pdf", "first"u8.ToArray(), "First CV");
         var secondDocument = await UploadDocumentAsync(client, "cv", "second-cv.pdf", "application/pdf", "second"u8.ToArray(), "Second CV");
 
-        var deleteResponse = await client.DeleteAsync($"/api/documents/{firstDocument.Id}");
+        var deleteResponse = await client.DeleteAsync($"/api/users/documents/{firstDocument.Id}");
         Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
-        var documents = await client.GetFromJsonAsync<List<UserDocumentResponse>>("/api/documents");
+        var documents = await client.GetFromJsonAsync<List<UserDocumentResponse>>("/api/users/documents");
         Assert.IsNotNull(documents);
         Assert.HasCount(1, documents);
         Assert.AreEqual(secondDocument.Id, documents[0].Id);
@@ -115,7 +115,7 @@ public class UserDocumentEndpointsTests
             fileBytes: [1, 2, 3, 4],
             displayName: "Unsafe CV");
 
-        var uploadResponse = await client.PostAsync("/api/documents", uploadContent);
+        var uploadResponse = await client.PostAsync("/api/users/documents", uploadContent);
 
         Assert.AreEqual(HttpStatusCode.BadRequest, uploadResponse.StatusCode);
     }
@@ -151,7 +151,7 @@ public class UserDocumentEndpointsTests
         string displayName)
     {
         using var uploadContent = CreateUploadContent(documentType, fileName, contentType, fileBytes, displayName);
-        var response = await client.PostAsync("/api/documents", uploadContent);
+        var response = await client.PostAsync("/api/users/documents", uploadContent);
         response.EnsureSuccessStatusCode();
 
         var document = await response.Content.ReadFromJsonAsync<UserDocumentResponse>();

--- a/services/api/tests/Firefly.Signal.Identity.FunctionalTests/UserProfileEndpointsTests.cs
+++ b/services/api/tests/Firefly.Signal.Identity.FunctionalTests/UserProfileEndpointsTests.cs
@@ -1,0 +1,170 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Firefly.Signal.Identity.Application;
+using Firefly.Signal.Identity.Domain;
+using Firefly.Signal.Identity.Infrastructure.Persistence;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Firefly.Signal.Identity.FunctionalTests;
+
+[TestClass]
+public class UserProfileEndpointsTests
+{
+    [TestMethod]
+    public async Task Get_profile_returns_not_found_when_current_user_has_no_profile()
+    {
+        await using var factory = CreateFactory();
+        SeedIdentityData(factory.Services);
+        using var client = factory.CreateClient();
+        var login = await LoginAsAdminAsync(client);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", login.AccessToken);
+
+        var response = await client.GetAsync("/api/users/profile");
+
+        Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task Put_profile_creates_current_user_profile_when_missing()
+    {
+        await using var factory = CreateFactory();
+        SeedIdentityData(factory.Services);
+        using var client = factory.CreateClient();
+        var login = await LoginAsAdminAsync(client);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", login.AccessToken);
+
+        var response = await client.PutAsJsonAsync(
+            "/api/users/profile",
+            new UserProfileRequest(
+                "Ada Lovelace",
+                "Senior Developer",
+                "sw1a 1aa",
+                "https://linkedin.com/in/ada",
+                "https://github.com/ada",
+                "https://ada.dev",
+                "Focused on backend and platform engineering.",
+                "C#, .NET, PostgreSQL",
+                "Built maintainable systems across product and infrastructure.",
+                "{\"preferredJobTypes\":[\"backend\"]}"));
+
+        Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+        var profile = await response.Content.ReadFromJsonAsync<UserProfileResponse>();
+
+        Assert.IsNotNull(profile);
+        Assert.AreEqual("Ada Lovelace", profile.FullName);
+        Assert.AreEqual("SW1A 1AA", profile.PrimaryLocationPostcode);
+        Assert.AreEqual("{\"preferredJobTypes\":[\"backend\"]}", profile.PreferencesJson);
+    }
+
+    [TestMethod]
+    public async Task Put_profile_updates_existing_current_user_profile()
+    {
+        await using var factory = CreateFactory();
+        SeedIdentityData(factory.Services);
+        SeedExistingProfile(factory.Services);
+        using var client = factory.CreateClient();
+        var login = await LoginAsAdminAsync(client);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", login.AccessToken);
+
+        var response = await client.PutAsJsonAsync(
+            "/api/users/profile",
+            new UserProfileRequest(
+                "Ada Lovelace",
+                "Principal Engineer",
+                "ec1a 1bb",
+                "https://linkedin.com/in/ada-updated",
+                "https://github.com/ada",
+                "https://ada.dev",
+                "Updated summary",
+                "C#, .NET, Azure",
+                "Updated experience summary",
+                "{\"preferredJobTypes\":[\"backend\",\"platform\"]}"));
+
+        response.EnsureSuccessStatusCode();
+        var profile = await response.Content.ReadFromJsonAsync<UserProfileResponse>();
+
+        Assert.IsNotNull(profile);
+        Assert.AreEqual("Principal Engineer", profile.PreferredTitle);
+        Assert.AreEqual("EC1A 1BB", profile.PrimaryLocationPostcode);
+
+        var getResponse = await client.GetAsync("/api/users/profile");
+        getResponse.EnsureSuccessStatusCode();
+
+        var persistedProfile = await getResponse.Content.ReadFromJsonAsync<UserProfileResponse>();
+        Assert.IsNotNull(persistedProfile);
+        Assert.AreEqual("Updated summary", persistedProfile.Summary);
+        Assert.AreEqual("{\"preferredJobTypes\":[\"backend\",\"platform\"]}", persistedProfile.PreferencesJson);
+    }
+
+    private static WebApplicationFactory<Firefly.Signal.Identity.Api.Program> CreateFactory()
+    {
+        var databaseName = $"identity-profile-tests-{Guid.NewGuid():N}";
+
+        return new WebApplicationFactory<Firefly.Signal.Identity.Api.Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Testing");
+                builder.UseSetting("Testing:DatabaseName", databaseName);
+            });
+    }
+
+    private static async Task<LoginResponse> LoginAsAdminAsync(HttpClient client)
+    {
+        var response = await client.PostAsJsonAsync("/api/auth/login", new LoginUserRequest("admin", "Admin123!"));
+        response.EnsureSuccessStatusCode();
+
+        var login = await response.Content.ReadFromJsonAsync<LoginResponse>();
+        Assert.IsNotNull(login);
+        return login;
+    }
+
+    private static void SeedIdentityData(IServiceProvider services)
+    {
+        using var scope = services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<IdentityDbContext>();
+        var passwordHasher = scope.ServiceProvider.GetRequiredService<IPasswordHasher<UserAccount>>();
+
+        if (dbContext.Users.Any())
+        {
+            return;
+        }
+
+        var admin = UserAccount.Create("admin", string.Empty, "admin@firefly.local", "Firefly Admin", Roles.Admin);
+        admin.ChangePassword(passwordHasher.HashPassword(admin, "Admin123!"));
+
+        dbContext.Users.Add(admin);
+        dbContext.SaveChanges();
+    }
+
+    private static void SeedExistingProfile(IServiceProvider services)
+    {
+        using var scope = services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<IdentityDbContext>();
+        var admin = dbContext.Users.Single(x => x.UserAccountName == "admin");
+
+        if (dbContext.UserProfiles.Any(x => x.UserAccountId == admin.Id))
+        {
+            return;
+        }
+
+        dbContext.UserProfiles.Add(
+            UserProfile.Create(
+                admin.Id,
+                "Ada Lovelace",
+                "Senior Developer",
+                "SW1A 1AA",
+                "https://linkedin.com/in/ada",
+                "https://github.com/ada",
+                "https://ada.dev",
+                "Original summary",
+                "C#, .NET",
+                "Original experience",
+                "{\"preferredJobTypes\":[\"backend\"]}"));
+
+        dbContext.SaveChanges();
+    }
+}


### PR DESCRIPTION
Closes #39

## Summary
- add current-user profile fetch and upsert endpoints in the Identity API
- add a real authenticated profile page and route in the web app
- align identity route shapes with the gateway  forwarding pattern and cover the nav active-state regression

## Validation
- dotnet test services/api/tests/Firefly.Signal.Identity.FunctionalTests/Firefly.Signal.Identity.FunctionalTests.csproj
- dotnet build services/api/Firefly.Signal.Api.slnx
- npm test
- npm run lint
- npm run build