### PR TITLE
feat(job-search): add admin imports and json export flows (#55)

### DIFF
--- a/apps/web/src/api/jobs/jobs.api.ts
+++ b/apps/web/src/api/jobs/jobs.api.ts
@@ -1,10 +1,21 @@
-import { deleteJson, deleteRequest, getJson, postJson, putJson } from "@/lib/http/client";
+import {
+  deleteJson,
+  deleteRequest,
+  getBlob,
+  getJson,
+  postFormData,
+  postJson,
+  putJson
+} from "@/lib/http/client";
 import type {
   CreateJobRequestDto,
   DeleteJobsResponseDto,
+  ExportJobsResponseDto,
   GetJobsPageQueryDto,
   HideJobsResponseDto,
   IdBatchRequestDto,
+  ImportJobsFromProviderRequestDto,
+  ImportJobsResponseDto,
   JobDetailsResponseDto,
   JobsPageResponseDto,
   UpdateJobRequestDto
@@ -67,6 +78,40 @@ export async function deleteJob(jobId: number): Promise<void> {
 
 export async function deleteJobs(ids: number[]): Promise<DeleteJobsResponseDto> {
   return deleteJson<DeleteJobsResponseDto, IdBatchRequestDto>("/api/job-search/jobs", { ids });
+}
+
+export async function importJobsFromProvider(
+  request: ImportJobsFromProviderRequestDto
+): Promise<ImportJobsResponseDto> {
+  return postJson<ImportJobsResponseDto, ImportJobsFromProviderRequestDto>(
+    "/api/job-search/jobs/import/provider",
+    request
+  );
+}
+
+export async function importJobsFromJson(file: File): Promise<ImportJobsResponseDto> {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  return postFormData<ImportJobsResponseDto>("/api/job-search/jobs/import/json", formData);
+}
+
+export async function exportJobs(query: GetJobsPageQueryDto): Promise<ExportJobsResponseDto> {
+  const searchParams = new URLSearchParams();
+
+  appendOptional(searchParams, "keyword", query.keyword);
+  appendOptional(searchParams, "company", query.company);
+  appendOptional(searchParams, "postcode", query.postcode);
+  appendOptional(searchParams, "location", query.location);
+  appendOptional(searchParams, "sourceName", query.sourceName);
+  appendOptional(searchParams, "categoryTag", query.categoryTag);
+
+  if (query.isHidden !== undefined) {
+    searchParams.set("isHidden", String(query.isHidden));
+  }
+
+  const blob = await getBlob(`/api/job-search/jobs/export?${searchParams.toString()}`);
+  return JSON.parse(await blob.text()) as ExportJobsResponseDto;
 }
 
 function appendOptional(params: URLSearchParams, key: string, value: string | undefined) {

--- a/apps/web/src/api/jobs/jobs.types.ts
+++ b/apps/web/src/api/jobs/jobs.types.ts
@@ -113,3 +113,40 @@ export type DeleteJobsResponseDto = {
 export type IdBatchRequestDto = {
   ids: number[];
 };
+
+export type ImportJobsFromProviderRequestDto = {
+  postcode: string;
+  keyword: string;
+  pageIndex?: number;
+  pageSize?: number;
+  provider?: "Adzuna";
+  excludedKeyword?: string;
+  distanceKilometers?: number;
+  category?: string;
+  salaryMin?: number;
+  salaryMax?: number;
+  fullTime?: boolean;
+  partTime?: boolean;
+  permanent?: boolean;
+  contract?: boolean;
+  sortBy?: string;
+  maxDaysOld?: number;
+  company?: string;
+  titleOnly?: boolean;
+  location0?: string;
+  location1?: string;
+  location2?: string;
+};
+
+export type ImportJobsResponseDto = {
+  jobRefreshRunId: number;
+  source: string;
+  importedCount: number;
+  failedCount: number;
+};
+
+export type ExportJobsResponseDto = {
+  exportedAtUtc: string;
+  count: number;
+  jobs: JobDetailsResponseDto[];
+};

--- a/apps/web/src/features/jobs/components/JobsImportPanel.tsx
+++ b/apps/web/src/features/jobs/components/JobsImportPanel.tsx
@@ -1,0 +1,84 @@
+import AddRoundedIcon from "@mui/icons-material/AddRounded";
+import CloudDownloadRoundedIcon from "@mui/icons-material/CloudDownloadRounded";
+import CloudUploadRoundedIcon from "@mui/icons-material/CloudUploadRounded";
+import DownloadRoundedIcon from "@mui/icons-material/DownloadRounded";
+import { Button } from "@mui/material";
+
+type JobsImportPanelProps = {
+  isProcessing: boolean;
+  onCreateJob: () => void;
+  onImportProvider: () => void;
+  onImportJson: () => void;
+  onExportJson: () => void;
+};
+
+export function JobsImportPanel({
+  isProcessing,
+  onCreateJob,
+  onImportProvider,
+  onImportJson,
+  onExportJson
+}: JobsImportPanelProps) {
+  return (
+    <div className="mb-6 rounded-2xl border border-border bg-background-elevated p-5">
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="font-mono text-xs tracking-[0.18em] text-foreground-tertiary">
+              IMPORT AND EXPORT
+            </p>
+            <h2 className="mt-2 font-serif text-2xl font-semibold text-foreground">
+              Provider and JSON tools
+            </h2>
+            <p className="mt-2 max-w-3xl text-sm text-foreground-secondary">
+              Create a manual job, trigger a provider import into PostgreSQL, upload a JSON export
+              back into the catalog, or export the currently filtered stored jobs to JSON.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <Button
+              variant="outlined"
+              color="inherit"
+              startIcon={<AddRoundedIcon />}
+              disabled={isProcessing}
+              onClick={onCreateJob}
+            >
+              New job
+            </Button>
+            <Button
+              variant="outlined"
+              color="inherit"
+              startIcon={<DownloadRoundedIcon />}
+              disabled={isProcessing}
+              onClick={onExportJson}
+            >
+              {isProcessing ? "Working..." : "Export JSON"}
+            </Button>
+            <Button
+              variant="outlined"
+              color="inherit"
+              startIcon={<CloudUploadRoundedIcon />}
+              disabled={isProcessing}
+              onClick={onImportJson}
+            >
+              {isProcessing ? "Working..." : "Import JSON"}
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={<CloudDownloadRoundedIcon />}
+              disabled={isProcessing}
+              onClick={onImportProvider}
+              sx={{
+                bgcolor: "accent.main",
+                "&:hover": { bgcolor: "accent.dark" }
+              }}
+            >
+              {isProcessing ? "Working..." : "Import from provider"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/jobs/components/JobsImportProviderDialog.tsx
+++ b/apps/web/src/features/jobs/components/JobsImportProviderDialog.tsx
@@ -1,0 +1,233 @@
+import { Checkbox, Dialog, DialogActions, DialogContent, DialogTitle, Button, FormControlLabel, MenuItem, TextField } from "@mui/material";
+
+export type JobsImportProviderFormValues = {
+  postcode: string;
+  keyword: string;
+  pageIndex: string;
+  pageSize: string;
+  provider: "Adzuna";
+  excludedKeyword: string;
+  distanceKilometers: string;
+  category: string;
+  salaryMin: string;
+  salaryMax: string;
+  fullTime: "" | "true" | "false";
+  partTime: "" | "true" | "false";
+  permanent: "" | "true" | "false";
+  contract: "" | "true" | "false";
+  sortBy: string;
+  maxDaysOld: string;
+  company: string;
+  titleOnly: boolean;
+  location0: string;
+  location1: string;
+  location2: string;
+};
+
+type JobsImportProviderDialogProps = {
+  isOpen: boolean;
+  isSubmitting: boolean;
+  values: JobsImportProviderFormValues;
+  onChange: (values: JobsImportProviderFormValues) => void;
+  onClose: () => void;
+  onSubmit: () => void;
+};
+
+export function JobsImportProviderDialog({
+  isOpen,
+  isSubmitting,
+  values,
+  onChange,
+  onClose,
+  onSubmit
+}: JobsImportProviderDialogProps) {
+  return (
+    <Dialog open={isOpen} onClose={isSubmitting ? undefined : onClose} fullWidth maxWidth="md">
+      <DialogTitle>Import jobs from provider</DialogTitle>
+      <DialogContent>
+        <div className="grid gap-4 pt-2 md:grid-cols-2">
+          <TextField
+            label="Postcode"
+            required
+            size="small"
+            value={values.postcode}
+            onChange={(event) => onChange({ ...values, postcode: event.target.value })}
+          />
+          <TextField
+            label="Keyword"
+            required
+            size="small"
+            value={values.keyword}
+            onChange={(event) => onChange({ ...values, keyword: event.target.value })}
+          />
+          <TextField
+            select
+            label="Provider"
+            size="small"
+            value={values.provider}
+            onChange={(event) =>
+              onChange({ ...values, provider: event.target.value as "Adzuna" })
+            }
+          >
+            <MenuItem value="Adzuna">Adzuna</MenuItem>
+          </TextField>
+          <TextField
+            label="Excluded keyword"
+            size="small"
+            value={values.excludedKeyword}
+            onChange={(event) => onChange({ ...values, excludedKeyword: event.target.value })}
+          />
+          <TextField
+            label="Page index"
+            size="small"
+            type="number"
+            value={values.pageIndex}
+            onChange={(event) => onChange({ ...values, pageIndex: event.target.value })}
+          />
+          <TextField
+            label="Page size"
+            size="small"
+            type="number"
+            value={values.pageSize}
+            onChange={(event) => onChange({ ...values, pageSize: event.target.value })}
+          />
+          <TextField
+            label="Distance (km)"
+            size="small"
+            type="number"
+            value={values.distanceKilometers}
+            onChange={(event) => onChange({ ...values, distanceKilometers: event.target.value })}
+          />
+          <TextField
+            label="Category"
+            size="small"
+            value={values.category}
+            onChange={(event) => onChange({ ...values, category: event.target.value })}
+          />
+          <TextField
+            label="Salary min"
+            size="small"
+            type="number"
+            value={values.salaryMin}
+            onChange={(event) => onChange({ ...values, salaryMin: event.target.value })}
+          />
+          <TextField
+            label="Salary max"
+            size="small"
+            type="number"
+            value={values.salaryMax}
+            onChange={(event) => onChange({ ...values, salaryMax: event.target.value })}
+          />
+          <TextField
+            select
+            label="Full time"
+            size="small"
+            value={values.fullTime}
+            onChange={(event) => onChange({ ...values, fullTime: event.target.value as JobsImportProviderFormValues["fullTime"] })}
+          >
+            <MenuItem value="">Any</MenuItem>
+            <MenuItem value="true">Yes</MenuItem>
+            <MenuItem value="false">No</MenuItem>
+          </TextField>
+          <TextField
+            select
+            label="Part time"
+            size="small"
+            value={values.partTime}
+            onChange={(event) => onChange({ ...values, partTime: event.target.value as JobsImportProviderFormValues["partTime"] })}
+          >
+            <MenuItem value="">Any</MenuItem>
+            <MenuItem value="true">Yes</MenuItem>
+            <MenuItem value="false">No</MenuItem>
+          </TextField>
+          <TextField
+            select
+            label="Permanent"
+            size="small"
+            value={values.permanent}
+            onChange={(event) => onChange({ ...values, permanent: event.target.value as JobsImportProviderFormValues["permanent"] })}
+          >
+            <MenuItem value="">Any</MenuItem>
+            <MenuItem value="true">Yes</MenuItem>
+            <MenuItem value="false">No</MenuItem>
+          </TextField>
+          <TextField
+            select
+            label="Contract"
+            size="small"
+            value={values.contract}
+            onChange={(event) => onChange({ ...values, contract: event.target.value as JobsImportProviderFormValues["contract"] })}
+          >
+            <MenuItem value="">Any</MenuItem>
+            <MenuItem value="true">Yes</MenuItem>
+            <MenuItem value="false">No</MenuItem>
+          </TextField>
+          <TextField
+            label="Sort by"
+            size="small"
+            value={values.sortBy}
+            onChange={(event) => onChange({ ...values, sortBy: event.target.value })}
+          />
+          <TextField
+            label="Max days old"
+            size="small"
+            type="number"
+            value={values.maxDaysOld}
+            onChange={(event) => onChange({ ...values, maxDaysOld: event.target.value })}
+          />
+          <TextField
+            label="Company"
+            size="small"
+            value={values.company}
+            onChange={(event) => onChange({ ...values, company: event.target.value })}
+          />
+          <TextField
+            label="Location 0"
+            size="small"
+            value={values.location0}
+            onChange={(event) => onChange({ ...values, location0: event.target.value })}
+          />
+          <TextField
+            label="Location 1"
+            size="small"
+            value={values.location1}
+            onChange={(event) => onChange({ ...values, location1: event.target.value })}
+          />
+          <TextField
+            label="Location 2"
+            size="small"
+            value={values.location2}
+            onChange={(event) => onChange({ ...values, location2: event.target.value })}
+          />
+        </div>
+
+        <FormControlLabel
+          className="mt-4"
+          control={
+            <Checkbox
+              checked={values.titleOnly}
+              onChange={(event) => onChange({ ...values, titleOnly: event.target.checked })}
+            />
+          }
+          label="Search title only"
+        />
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 3 }}>
+        <Button onClick={onClose} color="inherit" disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button
+          onClick={onSubmit}
+          variant="contained"
+          disabled={isSubmitting}
+          sx={{
+            bgcolor: "accent.main",
+            "&:hover": { bgcolor: "accent.dark" }
+          }}
+        >
+          {isSubmitting ? "Importing..." : "Run import"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/jobs/views/JobsListView.test.tsx
+++ b/apps/web/src/features/jobs/views/JobsListView.test.tsx
@@ -4,19 +4,32 @@ import { ThemeProvider } from "@mui/material";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { theme } from "@/app/theme";
-import { getJobsPage, hideJobs } from "@/api/jobs/jobs.api";
+import {
+  exportJobs,
+  getJobsPage,
+  hideJobs,
+  importJobsFromJson,
+  importJobsFromProvider
+} from "@/api/jobs/jobs.api";
 import { JobsListView } from "@/features/jobs/views/JobsListView";
 import { useSessionStore } from "@/store/session.store";
 
 vi.mock("@/api/jobs/jobs.api", () => ({
   deleteJobs: vi.fn(),
+  exportJobs: vi.fn(),
   getJobsPage: vi.fn(),
-  hideJobs: vi.fn()
+  hideJobs: vi.fn(),
+  importJobsFromJson: vi.fn(),
+  importJobsFromProvider: vi.fn()
 }));
 
 describe("JobsListView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn(() => "blob:jobs-export"),
+      revokeObjectURL: vi.fn()
+    });
     useSessionStore.setState({
       user: {
         userAccount: "admin",
@@ -113,4 +126,87 @@ describe("JobsListView", () => {
       })
     );
   }, 10000);
+
+  it("supports provider import, json import, and json export for admin users", async () => {
+    const user = userEvent.setup();
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
+
+    vi.mocked(getJobsPage).mockResolvedValue({
+      pageIndex: 0,
+      pageSize: 20,
+      totalCount: 0,
+      items: []
+    });
+
+    vi.mocked(importJobsFromProvider).mockResolvedValue({
+      jobRefreshRunId: 1,
+      source: "Adzuna",
+      importedCount: 2,
+      failedCount: 0
+    });
+
+    vi.mocked(importJobsFromJson).mockResolvedValue({
+      jobRefreshRunId: 2,
+      source: "json-upload",
+      importedCount: 1,
+      failedCount: 0
+    });
+
+    vi.mocked(exportJobs).mockResolvedValue({
+      exportedAtUtc: "2026-04-11T10:00:00Z",
+      count: 1,
+      jobs: []
+    });
+
+    render(
+      <ThemeProvider theme={theme}>
+        <MemoryRouter initialEntries={["/admin/manage-jobs"]}>
+          <JobsListView />
+        </MemoryRouter>
+      </ThemeProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Manage jobs" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Import from provider" }));
+    await user.type(screen.getByRole("textbox", { name: "Keyword" }), "frontend engineer");
+    await user.type(screen.getByRole("textbox", { name: "Postcode" }), "SW1A 1AA");
+    await user.click(screen.getByRole("button", { name: "Run import" }));
+
+    await waitFor(() => {
+      expect(importJobsFromProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          keyword: "frontend engineer",
+          postcode: "SW1A 1AA",
+          pageIndex: 0,
+          pageSize: 20,
+          provider: "Adzuna"
+        })
+      );
+    });
+
+    const file = new File(
+      [JSON.stringify({ exportedAtUtc: "2026-04-11T10:00:00Z", count: 1, jobs: [] })],
+      "jobs.json",
+      { type: "application/json" }
+    );
+
+    const fileInput = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    await user.upload(fileInput, file);
+
+    await waitFor(() => {
+      expect(importJobsFromJson).toHaveBeenCalledWith(file);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Export JSON" }));
+
+    await waitFor(() => {
+      expect(exportJobs).toHaveBeenCalled();
+      expect(clickSpy).toHaveBeenCalled();
+    });
+
+    clickSpy.mockRestore();
+  }, 30000);
 });

--- a/apps/web/src/features/jobs/views/JobsListView.tsx
+++ b/apps/web/src/features/jobs/views/JobsListView.tsx
@@ -1,13 +1,27 @@
-import AddRoundedIcon from "@mui/icons-material/AddRounded";
 import WorkOutlineRoundedIcon from "@mui/icons-material/WorkOutlineRounded";
-import { Alert, Button } from "@mui/material";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Alert } from "@mui/material";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppHeader } from "@/components/AppHeader";
 import { SectionCard } from "@/components/SectionCard";
-import { deleteJobs, getJobsPage, hideJobs } from "@/api/jobs/jobs.api";
-import type { DeleteJobsResponseDto } from "@/api/jobs/jobs.types";
+import {
+  deleteJobs,
+  exportJobs,
+  getJobsPage,
+  hideJobs,
+  importJobsFromJson,
+  importJobsFromProvider
+} from "@/api/jobs/jobs.api";
+import type {
+  DeleteJobsResponseDto,
+  ImportJobsFromProviderRequestDto
+} from "@/api/jobs/jobs.types";
 import { JobsManagementHeader } from "@/features/jobs/components/JobsManagementHeader";
+import { JobsImportPanel } from "@/features/jobs/components/JobsImportPanel";
+import {
+  JobsImportProviderDialog,
+  type JobsImportProviderFormValues
+} from "@/features/jobs/components/JobsImportProviderDialog";
 import {
   JobsManagementToolbar,
   type JobsListFilters,
@@ -28,6 +42,29 @@ const emptyFilters: JobsListFilters = {
 };
 
 const defaultPageSize = 20;
+const defaultImportForm: JobsImportProviderFormValues = {
+  postcode: "",
+  keyword: "",
+  pageIndex: "0",
+  pageSize: "20",
+  provider: "Adzuna",
+  excludedKeyword: "",
+  distanceKilometers: "",
+  category: "",
+  salaryMin: "",
+  salaryMax: "",
+  fullTime: "",
+  partTime: "",
+  permanent: "",
+  contract: "",
+  sortBy: "",
+  maxDaysOld: "",
+  company: "",
+  titleOnly: false,
+  location0: "",
+  location1: "",
+  location2: ""
+};
 
 export function JobsListView() {
   const navigate = useNavigate();
@@ -41,6 +78,9 @@ export function JobsListView() {
   const [actionMessage, setActionMessage] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
+  const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
+  const [importForm, setImportForm] = useState<JobsImportProviderFormValues>(defaultImportForm);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const loadJobs = useCallback(async (
     nextPageIndex: number,
@@ -129,34 +169,146 @@ export function JobsListView() {
     }
   }
 
+  async function handleProviderImport() {
+    if (!isAdmin) {
+      return;
+    }
+
+    const keyword = importForm.keyword.trim();
+    const postcode = importForm.postcode.trim();
+    if (!keyword || !postcode) {
+      setActionMessage(null);
+      setActionError("Enter both a keyword and postcode before importing from the provider.");
+      return;
+    }
+
+    setIsProcessing(true);
+    setActionMessage(null);
+    setActionError(null);
+
+    try {
+      const result = await importJobsFromProvider(buildImportRequest(importForm, keyword, postcode));
+      setActionMessage(`Imported ${result.importedCount} jobs from ${result.source}.`);
+      setIsImportDialogOpen(false);
+      await execute(pageIndex, pageSize, filters);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Unable to import jobs from the provider.");
+    } finally {
+      setIsProcessing(false);
+    }
+  }
+
+  async function handleJsonImport(file: File) {
+    if (!isAdmin) {
+      return;
+    }
+
+    setIsProcessing(true);
+    setActionMessage(null);
+    setActionError(null);
+
+    try {
+      const result = await importJobsFromJson(file);
+      setActionMessage(`Imported ${result.importedCount} jobs from ${file.name}.`);
+      await execute(pageIndex, pageSize, filters);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Unable to import jobs from JSON.");
+    } finally {
+      setIsProcessing(false);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
+  }
+
+  async function handleExport() {
+    if (!isAdmin) {
+      return;
+    }
+
+    setIsProcessing(true);
+    setActionMessage(null);
+    setActionError(null);
+
+    try {
+      const exportResult = await exportJobs({
+        pageIndex,
+        pageSize,
+        keyword: normalizeText(filters.keyword),
+        company: normalizeText(filters.company),
+        postcode: normalizeText(filters.postcode),
+        location: normalizeText(filters.location),
+        sourceName: normalizeText(filters.sourceName),
+        categoryTag: normalizeText(filters.categoryTag),
+        isHidden: mapVisibilityToHiddenFlag(filters.visibility)
+      });
+
+      const blob = new Blob([JSON.stringify(exportResult, null, 2)], {
+        type: "application/json"
+      });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = `jobs-export-${new Date().toISOString().replaceAll(":", "-")}.json`;
+      anchor.click();
+      URL.revokeObjectURL(url);
+
+      setActionMessage(`Exported ${exportResult.count} jobs to JSON.`);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Unable to export jobs to JSON.");
+    } finally {
+      setIsProcessing(false);
+    }
+  }
+
   return (
     <div className="min-h-screen bg-background">
-      <AppHeader
-        variant="authenticated"
-        actions={
-          isAdmin ? (
-            <Button
-              onClick={() => void navigate("/admin/manage-jobs/new")}
-              variant="contained"
-              startIcon={<AddRoundedIcon />}
-              sx={{
-                bgcolor: "accent.main",
-                "&:hover": { bgcolor: "accent.dark" }
-              }}
-            >
-              New job
-            </Button>
-          ) : null
-        }
-      />
+      <AppHeader variant="authenticated" />
 
       <div className="mx-auto max-w-[1400px] px-5 py-8 sm:px-8">
         <JobsManagementHeader totalCount={totalCount} />
 
+        {isAdmin ? (
+          <>
+            <JobsImportPanel
+              isProcessing={isProcessing}
+              onCreateJob={() => void navigate("/admin/manage-jobs/new")}
+              onExportJson={() => void handleExport()}
+              onImportJson={() => fileInputRef.current?.click()}
+              onImportProvider={() => setIsImportDialogOpen(true)}
+            />
+            <JobsImportProviderDialog
+              isOpen={isImportDialogOpen}
+              isSubmitting={isProcessing}
+              values={importForm}
+              onChange={setImportForm}
+              onClose={() => {
+                if (!isProcessing) {
+                  setIsImportDialogOpen(false);
+                }
+              }}
+              onSubmit={() => void handleProviderImport()}
+            />
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,application/json"
+              className="hidden"
+              onChange={(event) => {
+                const file = event.target.files?.[0];
+                if (file) {
+                  void handleJsonImport(file);
+                }
+              }}
+            />
+          </>
+        ) : null}
+
         {!isAdmin ? (
           <Alert severity="warning" sx={{ mb: 4 }}>
             This route is intended for admin job management. Your session can read jobs, but batch
-            hide, batch delete, and edit actions require the admin role from the backend API.
+            hide, batch delete, edit, import, and export actions require the admin role from the
+            backend API.
           </Alert>
         ) : null}
 
@@ -245,6 +397,54 @@ function mapVisibilityToHiddenFlag(value: VisibilityFilter): boolean | undefined
 function normalizeText(value: string): string | undefined {
   const trimmed = value.trim();
   return trimmed ? trimmed : undefined;
+}
+
+function parseOptionalNumber(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseOptionalBoolean(value: "" | "true" | "false"): boolean | undefined {
+  if (value === "") {
+    return undefined;
+  }
+
+  return value === "true";
+}
+
+function buildImportRequest(
+  values: JobsImportProviderFormValues,
+  keyword: string,
+  postcode: string
+): ImportJobsFromProviderRequestDto {
+  return {
+    postcode,
+    keyword,
+    pageIndex: parseOptionalNumber(values.pageIndex) ?? 0,
+    pageSize: parseOptionalNumber(values.pageSize) ?? 20,
+    provider: values.provider,
+    excludedKeyword: normalizeText(values.excludedKeyword),
+    distanceKilometers: parseOptionalNumber(values.distanceKilometers),
+    category: normalizeText(values.category),
+    salaryMin: parseOptionalNumber(values.salaryMin),
+    salaryMax: parseOptionalNumber(values.salaryMax),
+    fullTime: parseOptionalBoolean(values.fullTime),
+    partTime: parseOptionalBoolean(values.partTime),
+    permanent: parseOptionalBoolean(values.permanent),
+    contract: parseOptionalBoolean(values.contract),
+    sortBy: normalizeText(values.sortBy),
+    maxDaysOld: parseOptionalNumber(values.maxDaysOld),
+    company: normalizeText(values.company),
+    titleOnly: values.titleOnly,
+    location0: normalizeText(values.location0),
+    location1: normalizeText(values.location1),
+    location2: normalizeText(values.location2)
+  };
 }
 
 function buildHideSummary(hiddenCount: number, missingCount: number): string {

--- a/apps/web/src/lib/http/client.ts
+++ b/apps/web/src/lib/http/client.ts
@@ -36,6 +36,30 @@ export async function putJson<TResponse, TBody>(
   });
 }
 
+export async function postFormData<TResponse>(
+  path: string,
+  body: FormData,
+  init?: Omit<RequestInit, "method" | "body">
+): Promise<TResponse> {
+  return requestJson<TResponse>(path, {
+    ...init,
+    method: "POST",
+    body
+  });
+}
+
+export async function getBlob(
+  path: string,
+  init?: Omit<RequestInit, "method">
+): Promise<Blob> {
+  const response = await request(path, {
+    ...init,
+    method: "GET"
+  });
+
+  return response.blob();
+}
+
 export async function deleteRequest(
   path: string,
   init?: Omit<RequestInit, "method">
@@ -74,7 +98,7 @@ async function request(path: string, init: RequestInit): Promise<Response> {
     ...init,
     headers: {
       Accept: "application/json",
-      ...(init.body ? { "Content-Type": "application/json" } : {}),
+      ...(init.body && !(init.body instanceof FormData) ? { "Content-Type": "application/json" } : {}),
       ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
       ...init?.headers
     }

--- a/docs/backend-designs.md
+++ b/docs/backend-designs.md
@@ -144,6 +144,7 @@ Do not force async workflows into the first implementation if synchronous reques
 - Normalize provider-specific quirks before they reach the frontend.
 - Keep search, workflow, profile, and AI contracts explicit and typed.
 - Design bulk admin and AI-selection workflows carefully so they remain reviewable and auditable.
+- Keep admin job-catalog operations under `/api/job-search/jobs/...`, including CRUD, moderation, provider import, JSON import, and JSON export endpoints.
 
 ## Operational Guidance
 - Use Docker Compose locally for PostgreSQL, pgweb, RabbitMQ, Redis, and service containers when they exist.

--- a/docs/backend-designs/adzuna-api.md
+++ b/docs/backend-designs/adzuna-api.md
@@ -96,6 +96,7 @@ To avoid burning Adzuna rate limits during routine development:
 - Firefly Signal uses a mock Adzuna provider by default
 - live Adzuna calls are opt-in through configuration
 - backend unit and functional tests do not call the real Adzuna API
+- admin-triggered provider import flows should continue to work against the mock provider in local development
 
 Current configuration behavior:
 

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Application/IJobSearchService.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Application/IJobSearchService.cs
@@ -6,8 +6,11 @@ public interface IJobSearchService
 {
     Task<JobDetailsResponse?> GetByIdAsync(long id, CancellationToken cancellationToken = default);
     Task<Paged<JobDetailsResponse>> GetPageAsync(GetJobsPageRequest request, CancellationToken cancellationToken = default);
+    Task<ExportJobsResponse> ExportAsync(ExportJobsRequest request, CancellationToken cancellationToken = default);
     Task<JobDetailsResponse> CreateAsync(CreateJobRequest request, CancellationToken cancellationToken = default);
     Task<JobDetailsResponse?> UpdateAsync(long id, UpdateJobRequest request, CancellationToken cancellationToken = default);
+    Task<ImportJobsResponse> ImportFromProviderAsync(ImportJobsFromProviderRequest request, CancellationToken cancellationToken = default);
+    Task<ImportJobsResponse> ImportFromJsonAsync(Stream jsonStream, string fileName, CancellationToken cancellationToken = default);
     Task<HideJobsResponse> HideAsync(IReadOnlyCollection<long> ids, CancellationToken cancellationToken = default);
     Task<DeleteJobsResponse> DeleteAsync(IReadOnlyCollection<long> ids, CancellationToken cancellationToken = default);
 }

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Application/JobContracts.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Application/JobContracts.cs
@@ -51,6 +51,38 @@ public sealed record GetJobsPageRequest(
     string? CategoryTag = null,
     bool? IsHidden = false);
 
+public sealed record ExportJobsRequest(
+    string? Keyword = null,
+    string? Company = null,
+    string? Postcode = null,
+    string? Location = null,
+    string? SourceName = null,
+    string? CategoryTag = null,
+    bool? IsHidden = null);
+
+public sealed record ImportJobsFromProviderRequest(
+    string Postcode,
+    string Keyword,
+    int PageIndex = 0,
+    int PageSize = 20,
+    JobSearchProviderKind Provider = JobSearchProviderKind.Adzuna,
+    string? ExcludedKeyword = null,
+    int? DistanceKilometers = null,
+    string? Category = null,
+    decimal? SalaryMin = null,
+    decimal? SalaryMax = null,
+    bool? FullTime = null,
+    bool? PartTime = null,
+    bool? Permanent = null,
+    bool? Contract = null,
+    string? SortBy = null,
+    int? MaxDaysOld = null,
+    string? Company = null,
+    bool TitleOnly = false,
+    string? Location0 = null,
+    string? Location1 = null,
+    string? Location2 = null);
+
 public sealed record CreateJobRequest(
     long? JobRefreshRunId,
     string SourceName,
@@ -135,3 +167,14 @@ public sealed record DeleteJobsResponse(
     IReadOnlyList<long> DeletedIds,
     IReadOnlyList<long> MissingIds,
     IReadOnlyList<long> NotHiddenIds);
+
+public sealed record ImportJobsResponse(
+    long JobRefreshRunId,
+    string Source,
+    int ImportedCount,
+    int FailedCount);
+
+public sealed record ExportJobsResponse(
+    DateTime ExportedAtUtc,
+    int Count,
+    IReadOnlyList<JobDetailsResponse> Jobs);

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Endpoints/JobSearchEndpoints.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Endpoints/JobSearchEndpoints.cs
@@ -1,8 +1,10 @@
 using Firefly.Signal.JobSearch.Application;
+using Firefly.Signal.JobSearch.Infrastructure.External;
 using Firefly.Signal.SharedKernel.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using System.Text.Json;
 
 namespace Firefly.Signal.JobSearch.Endpoints;
 
@@ -22,6 +24,10 @@ public static class JobSearchEndpoints
         adminGroup.MapDelete("/", DeleteManyAsync);
         adminGroup.MapPost("/{id:long}/hide", HideByIdAsync);
         adminGroup.MapPost("/hide", HideManyAsync);
+        adminGroup.MapPost("/import/provider", ImportFromProviderAsync);
+        adminGroup.MapPost("/import/json", ImportFromJsonAsync)
+            .DisableAntiforgery();
+        adminGroup.MapGet("/export", ExportAsync);
 
         return endpoints;
     }
@@ -131,4 +137,102 @@ public static class JobSearchEndpoints
         [FromServices] IJobSearchService service,
         CancellationToken cancellationToken)
         => TypedResults.Ok(await service.HideAsync(request.Ids, cancellationToken));
+
+    private static async Task<Results<Ok<ImportJobsResponse>, BadRequest<ProblemDetails>>> ImportFromProviderAsync(
+        [FromBody] ImportJobsFromProviderRequest request,
+        [FromServices] IJobSearchService service,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return TypedResults.Ok(await service.ImportFromProviderAsync(request, cancellationToken));
+        }
+        catch (JobSearchProviderException exception)
+        {
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "Provider import failed",
+                Detail = exception.Message
+            });
+        }
+    }
+
+    private static async Task<Results<Ok<ImportJobsResponse>, BadRequest<ProblemDetails>>> ImportFromJsonAsync(
+        IFormFile? file,
+        [FromServices] IJobSearchService service,
+        CancellationToken cancellationToken)
+    {
+        if (file is null || file.Length == 0)
+        {
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "JSON file is required",
+                Detail = "Upload a non-empty JSON file containing exported jobs."
+            });
+        }
+
+        if (!file.FileName.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+        {
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "JSON file is required",
+                Detail = "The uploaded file must use a .json extension."
+            });
+        }
+
+        try
+        {
+            await using var stream = file.OpenReadStream();
+            return TypedResults.Ok(await service.ImportFromJsonAsync(stream, file.FileName, cancellationToken));
+        }
+        catch (InvalidDataException exception)
+        {
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "JSON import failed",
+                Detail = exception.Message
+            });
+        }
+        catch (JsonException)
+        {
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "JSON import failed",
+                Detail = "The uploaded file is not valid job export JSON."
+            });
+        }
+    }
+
+    private static async Task<FileContentHttpResult> ExportAsync(
+        [FromQuery] string? keyword,
+        [FromQuery] string? company,
+        [FromQuery] string? postcode,
+        [FromQuery] string? location,
+        [FromQuery] string? sourceName,
+        [FromQuery] string? categoryTag,
+        [FromQuery] bool? isHidden,
+        [FromServices] IJobSearchService service,
+        CancellationToken cancellationToken)
+    {
+        var export = await service.ExportAsync(
+            new ExportJobsRequest(
+                keyword,
+                company,
+                postcode,
+                location,
+                sourceName,
+                categoryTag,
+                isHidden),
+            cancellationToken);
+
+        var content = JsonSerializer.SerializeToUtf8Bytes(export, new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            WriteIndented = true
+        });
+
+        return TypedResults.File(
+            content,
+            "application/json",
+            $"jobs-export-{DateTime.UtcNow:yyyyMMdd-HHmmss}.json");
+    }
 }

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/Services/DbJobSearchService.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/Services/DbJobSearchService.cs
@@ -1,14 +1,24 @@
 using Firefly.Signal.JobSearch.Application;
 using Firefly.Signal.JobSearch.Domain;
+using Firefly.Signal.JobSearch.Infrastructure.External;
 using Firefly.Signal.JobSearch.Infrastructure.Persistence;
 using Firefly.Signal.SharedKernel.Models;
+using System.Text.Json;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Firefly.Signal.JobSearch.Infrastructure.Services;
 
-public sealed class DbJobSearchService(JobSearchDbContext dbContext) : IJobSearchService
+public sealed class DbJobSearchService(
+    JobSearchDbContext dbContext,
+    IJobSearchProvider jobSearchProvider) : IJobSearchService
 {
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
     public async Task<JobDetailsResponse?> GetByIdAsync(long id, CancellationToken cancellationToken = default)
         => await dbContext.Jobs
             .Where(x => x.Id == id)
@@ -20,56 +30,7 @@ public sealed class DbJobSearchService(JobSearchDbContext dbContext) : IJobSearc
         var pageIndex = Math.Max(request.PageIndex, 0);
         var pageSize = request.PageSize <= 0 ? 20 : request.PageSize;
 
-        var query = dbContext.Jobs.AsQueryable();
-
-        if (!string.IsNullOrWhiteSpace(request.Keyword))
-        {
-            var keyword = request.Keyword.Trim();
-            query = query.Where(x =>
-                x.Title.Contains(keyword) ||
-                x.Description.Contains(keyword) ||
-                x.Summary.Contains(keyword));
-        }
-
-        if (!string.IsNullOrWhiteSpace(request.Company))
-        {
-            var company = request.Company.Trim();
-            query = query.Where(x =>
-                x.Company.Contains(company) ||
-                (x.CompanyDisplayName != null && x.CompanyDisplayName.Contains(company)) ||
-                (x.CompanyCanonicalName != null && x.CompanyCanonicalName.Contains(company)));
-        }
-
-        if (!string.IsNullOrWhiteSpace(request.Postcode))
-        {
-            var postcode = request.Postcode.Trim().ToUpperInvariant();
-            query = query.Where(x => x.Postcode.Contains(postcode));
-        }
-
-        if (!string.IsNullOrWhiteSpace(request.Location))
-        {
-            var location = request.Location.Trim();
-            query = query.Where(x =>
-                x.LocationName.Contains(location) ||
-                (x.LocationDisplayName != null && x.LocationDisplayName.Contains(location)));
-        }
-
-        if (!string.IsNullOrWhiteSpace(request.SourceName))
-        {
-            var sourceName = request.SourceName.Trim();
-            query = query.Where(x => x.SourceName.Contains(sourceName));
-        }
-
-        if (!string.IsNullOrWhiteSpace(request.CategoryTag))
-        {
-            var categoryTag = request.CategoryTag.Trim();
-            query = query.Where(x => x.CategoryTag != null && x.CategoryTag.Contains(categoryTag));
-        }
-
-        if (request.IsHidden.HasValue)
-        {
-            query = query.Where(x => x.IsHidden == request.IsHidden.Value);
-        }
+        var query = ApplyFilters(dbContext.Jobs.AsQueryable(), request);
 
         var totalCount = await query.LongCountAsync(cancellationToken);
         var jobs = await query
@@ -81,6 +42,26 @@ public sealed class DbJobSearchService(JobSearchDbContext dbContext) : IJobSearc
             .ToListAsync(cancellationToken);
 
         return new Paged<JobDetailsResponse>(pageIndex, pageSize, totalCount, jobs);
+    }
+
+    public async Task<ExportJobsResponse> ExportAsync(ExportJobsRequest request, CancellationToken cancellationToken = default)
+    {
+        var jobs = await ApplyFilters(dbContext.Jobs.AsNoTracking(), new GetJobsPageRequest(
+                0,
+                int.MaxValue,
+                request.Keyword,
+                request.Company,
+                request.Postcode,
+                request.Location,
+                request.SourceName,
+                request.CategoryTag,
+                request.IsHidden))
+            .OrderByDescending(x => x.PostedAtUtc)
+            .ThenByDescending(x => x.Id)
+            .Select(ToResponse())
+            .ToListAsync(cancellationToken);
+
+        return new ExportJobsResponse(DateTime.UtcNow, jobs.Count, jobs);
     }
 
     public async Task<JobDetailsResponse> CreateAsync(CreateJobRequest request, CancellationToken cancellationToken = default)
@@ -177,6 +158,128 @@ public sealed class DbJobSearchService(JobSearchDbContext dbContext) : IJobSearc
         return Map(job);
     }
 
+    public async Task<ImportJobsResponse> ImportFromProviderAsync(
+        ImportJobsFromProviderRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var providerRequest = new SearchJobsRequest(
+            request.Postcode,
+            request.Keyword,
+            request.PageIndex,
+            request.PageSize,
+            request.Provider,
+            request.ExcludedKeyword,
+            request.DistanceKilometers,
+            request.Category,
+            request.SalaryMin,
+            request.SalaryMax,
+            request.FullTime,
+            request.PartTime,
+            request.Permanent,
+            request.Contract,
+            request.SortBy,
+            request.MaxDaysOld,
+            request.Company,
+            request.TitleOnly,
+            request.Location0,
+            request.Location1,
+            request.Location2);
+
+        var filtersJson = JsonSerializer.Serialize(request, JsonOptions);
+        var refreshRun = JobRefreshRun.Start(
+            request.Provider.ToString(),
+            "gb",
+            filtersJson,
+            request.PageSize,
+            requestedMaxPages: 1);
+
+        dbContext.JobRefreshRuns.Add(refreshRun);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        try
+        {
+            var providerResult = await jobSearchProvider.SearchAsync(providerRequest, cancellationToken);
+            refreshRun.RecordFetchedPage(providerResult.Jobs.Count);
+
+            var importedJobs = providerResult.Jobs
+                .Select(job => CloneImportedJob(job, refreshRun.Id))
+                .ToArray();
+
+            dbContext.Jobs.AddRange(importedJobs);
+            refreshRun.RecordInsertedJobs(importedJobs.Length);
+            refreshRun.RecordHiddenJobs(importedJobs.Count(job => job.IsHidden));
+            refreshRun.Complete();
+
+            await dbContext.SaveChangesAsync(cancellationToken);
+
+            return new ImportJobsResponse(refreshRun.Id, request.Provider.ToString(), importedJobs.Length, 0);
+        }
+        catch
+        {
+            refreshRun.RecordFailedItems(1);
+            refreshRun.Fail("Provider import failed.");
+            await dbContext.SaveChangesAsync(cancellationToken);
+            throw;
+        }
+    }
+
+    public async Task<ImportJobsResponse> ImportFromJsonAsync(
+        Stream jsonStream,
+        string fileName,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(jsonStream);
+
+        var payload = await JsonSerializer.DeserializeAsync<ImportedJobsFile>(
+            jsonStream,
+            JsonOptions,
+            cancellationToken);
+
+        if (payload?.Jobs is null || payload.Jobs.Count == 0)
+        {
+            throw new InvalidDataException($"The uploaded file '{fileName}' does not contain any jobs.");
+        }
+
+        var refreshRun = JobRefreshRun.Start(
+            "json-upload",
+            "gb",
+            JsonSerializer.Serialize(new
+            {
+                fileName,
+                jobCount = payload.Jobs.Count
+            }, JsonOptions),
+            payload.Jobs.Count,
+            requestedMaxPages: 1);
+
+        dbContext.JobRefreshRuns.Add(refreshRun);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        try
+        {
+            refreshRun.RecordFetchedPage(payload.Jobs.Count);
+
+            var importedJobs = payload.Jobs
+                .Select(job => CreateImportedJob(job, refreshRun.Id))
+                .ToArray();
+
+            dbContext.Jobs.AddRange(importedJobs);
+            refreshRun.RecordInsertedJobs(importedJobs.Length);
+            refreshRun.RecordHiddenJobs(importedJobs.Count(job => job.IsHidden));
+            refreshRun.Complete();
+
+            await dbContext.SaveChangesAsync(cancellationToken);
+
+            return new ImportJobsResponse(refreshRun.Id, "json-upload", importedJobs.Length, 0);
+        }
+        catch
+        {
+            refreshRun.RecordFailedItems(1);
+            refreshRun.Fail("JSON import failed.");
+            await dbContext.SaveChangesAsync(cancellationToken);
+            throw;
+        }
+    }
+
     public async Task<HideJobsResponse> HideAsync(IReadOnlyCollection<long> ids, CancellationToken cancellationToken = default)
     {
         if (ids.Count == 0)
@@ -232,6 +335,136 @@ public sealed class DbJobSearchService(JobSearchDbContext dbContext) : IJobSearc
         var missing = requestedIds.Except(deletedIds).ToArray();
         return new DeleteJobsResponse(deletedIds.Length, deletedIds, missing, []);
     }
+
+    private static IQueryable<JobPosting> ApplyFilters(IQueryable<JobPosting> query, GetJobsPageRequest request)
+    {
+        if (!string.IsNullOrWhiteSpace(request.Keyword))
+        {
+            var keyword = request.Keyword.Trim();
+            query = query.Where(x =>
+                x.Title.Contains(keyword) ||
+                x.Description.Contains(keyword) ||
+                x.Summary.Contains(keyword));
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Company))
+        {
+            var company = request.Company.Trim();
+            query = query.Where(x =>
+                x.Company.Contains(company) ||
+                (x.CompanyDisplayName != null && x.CompanyDisplayName.Contains(company)) ||
+                (x.CompanyCanonicalName != null && x.CompanyCanonicalName.Contains(company)));
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Postcode))
+        {
+            var postcode = request.Postcode.Trim().ToUpperInvariant();
+            query = query.Where(x => x.Postcode.Contains(postcode));
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Location))
+        {
+            var location = request.Location.Trim();
+            query = query.Where(x =>
+                x.LocationName.Contains(location) ||
+                (x.LocationDisplayName != null && x.LocationDisplayName.Contains(location)));
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.SourceName))
+        {
+            var sourceName = request.SourceName.Trim();
+            query = query.Where(x => x.SourceName.Contains(sourceName));
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.CategoryTag))
+        {
+            var categoryTag = request.CategoryTag.Trim();
+            query = query.Where(x => x.CategoryTag != null && x.CategoryTag.Contains(categoryTag));
+        }
+
+        if (request.IsHidden.HasValue)
+        {
+            query = query.Where(x => x.IsHidden == request.IsHidden.Value);
+        }
+
+        return query;
+    }
+
+    private static JobPosting CloneImportedJob(JobPosting source, long refreshRunId)
+        => JobPosting.Create(
+            refreshRunId,
+            source.SourceName,
+            source.SourceJobId,
+            source.SourceAdReference,
+            source.Title,
+            source.Description,
+            source.Summary,
+            source.Url,
+            source.Company,
+            source.CompanyDisplayName,
+            source.CompanyCanonicalName,
+            source.Postcode,
+            source.LocationName,
+            source.LocationDisplayName,
+            source.LocationAreaJson,
+            source.Latitude,
+            source.Longitude,
+            source.CategoryTag,
+            source.CategoryLabel,
+            source.SalaryMin,
+            source.SalaryMax,
+            source.SalaryCurrency,
+            source.SalaryIsPredicted,
+            source.ContractTime,
+            source.ContractType,
+            source.IsFullTime,
+            source.IsPartTime,
+            source.IsPermanent,
+            source.IsContract,
+            source.IsRemote,
+            source.PostedAtUtc,
+            DateTime.UtcNow,
+            DateTime.UtcNow,
+            source.IsHidden,
+            source.RawPayloadJson);
+
+    private static JobPosting CreateImportedJob(CreateJobRequest request, long refreshRunId)
+        => JobPosting.Create(
+            refreshRunId,
+            request.SourceName,
+            request.SourceJobId,
+            request.SourceAdReference,
+            request.Title,
+            request.Description,
+            request.Summary,
+            request.Url,
+            request.Company,
+            request.CompanyDisplayName,
+            request.CompanyCanonicalName,
+            request.Postcode,
+            request.LocationName,
+            request.LocationDisplayName,
+            request.LocationAreaJson,
+            request.Latitude,
+            request.Longitude,
+            request.CategoryTag,
+            request.CategoryLabel,
+            request.SalaryMin,
+            request.SalaryMax,
+            request.SalaryCurrency,
+            request.SalaryIsPredicted,
+            request.ContractTime,
+            request.ContractType,
+            request.IsFullTime,
+            request.IsPartTime,
+            request.IsPermanent,
+            request.IsContract,
+            request.IsRemote,
+            request.PostedAtUtc,
+            request.ImportedAtUtc == default ? DateTime.UtcNow : request.ImportedAtUtc,
+            request.LastSeenAtUtc == default ? DateTime.UtcNow : request.LastSeenAtUtc,
+            request.IsHidden,
+            request.RawPayloadJson);
 
     private static Expression<Func<JobPosting, JobDetailsResponse>> ToResponse()
         => job => new JobDetailsResponse(
@@ -309,4 +542,9 @@ public sealed class DbJobSearchService(JobSearchDbContext dbContext) : IJobSearc
         job.LastSeenAtUtc,
         job.IsHidden,
         job.RawPayloadJson);
+
+    private sealed record ImportedJobsFile(
+        DateTime? ExportedAtUtc,
+        int? Count,
+        IReadOnlyList<CreateJobRequest> Jobs);
 }

--- a/services/api/tests/Firefly.Signal.JobSearch.FunctionalTests/JobSearchApiTests.cs
+++ b/services/api/tests/Firefly.Signal.JobSearch.FunctionalTests/JobSearchApiTests.cs
@@ -1,9 +1,10 @@
 using System.IdentityModel.Tokens.Jwt;
-using System.Net;
 using System.Net.Http.Headers;
+using System.Net;
 using System.Net.Http.Json;
 using System.Security.Claims;
 using System.Text;
+using System.Text.Json;
 using Firefly.Signal.JobSearch.Application;
 using Firefly.Signal.JobSearch.Domain;
 using Firefly.Signal.JobSearch.Infrastructure.Persistence;
@@ -74,6 +75,70 @@ public class JobSearchApiTests
 
         var getResponse = await client.GetAsync($"/api/job-search/jobs/{jobId}");
         Assert.AreEqual(HttpStatusCode.NotFound, getResponse.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task Provider_import_persists_jobs_for_admin()
+    {
+        await using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateAccessToken());
+
+        var response = await client.PostAsJsonAsync("/api/job-search/jobs/import/provider", new
+        {
+            postcode = "SW1A 1AA",
+            keyword = "platform",
+            pageSize = 20
+        });
+
+        response.EnsureSuccessStatusCode();
+        var payload = await response.Content.ReadFromJsonAsync<ImportJobsResponse>();
+        Assert.IsNotNull(payload);
+        Assert.AreEqual(2, payload.ImportedCount);
+
+        await using var scope = factory.Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<JobSearchDbContext>();
+        Assert.AreEqual(2, await dbContext.Jobs.CountAsync());
+        Assert.AreEqual(1, await dbContext.JobRefreshRuns.CountAsync());
+    }
+
+    [TestMethod]
+    public async Task Export_returns_json_file_for_admin()
+    {
+        await using var factory = CreateFactory();
+        await SeedJobAsync(factory.Services);
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateAccessToken());
+
+        var response = await client.GetAsync("/api/job-search/jobs/export");
+
+        response.EnsureSuccessStatusCode();
+        Assert.AreEqual("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        var body = await response.Content.ReadAsStringAsync();
+        var payload = JsonSerializer.Deserialize<ExportJobsResponse>(body, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        Assert.IsNotNull(payload);
+        Assert.AreEqual(1, payload.Count);
+        Assert.AreEqual(".NET Backend Developer", payload.Jobs[0].Title);
+    }
+
+    [TestMethod]
+    public async Task Json_import_rejects_invalid_payload()
+    {
+        await using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateAccessToken());
+
+        using var content = new MultipartFormDataContent();
+        using var fileContent = new ByteArrayContent(Encoding.UTF8.GetBytes("{not-json"));
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        content.Add(fileContent, "file", "jobs.json");
+
+        var response = await client.PostAsync("/api/job-search/jobs/import/json", content);
+
+        Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+        var payload = await response.Content.ReadAsStringAsync();
+        StringAssert.Contains(payload, "JSON import failed");
     }
 
     private static WebApplicationFactory<Firefly.Signal.JobSearch.Api.Program> CreateFactory()

--- a/services/api/tests/Firefly.Signal.JobSearch.UnitTests/JobSearchServiceTests.cs
+++ b/services/api/tests/Firefly.Signal.JobSearch.UnitTests/JobSearchServiceTests.cs
@@ -1,5 +1,6 @@
 using Firefly.Signal.JobSearch.Application;
 using Firefly.Signal.JobSearch.Domain;
+using Firefly.Signal.JobSearch.Infrastructure.External;
 using Firefly.Signal.JobSearch.Infrastructure.Persistence;
 using Firefly.Signal.JobSearch.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
@@ -87,7 +88,7 @@ public class JobSearchServiceTests
             rawPayloadJson: "{}"));
         await dbContext.SaveChangesAsync();
 
-        var service = new DbJobSearchService(dbContext);
+        var service = new DbJobSearchService(dbContext, new NoOpJobSearchProvider());
 
         var result = await service.GetPageAsync(new GetJobsPageRequest(0, 20));
 
@@ -112,7 +113,7 @@ public class JobSearchServiceTests
         dbContext.Jobs.Add(job);
         await dbContext.SaveChangesAsync();
 
-        var service = new DbJobSearchService(dbContext);
+        var service = new DbJobSearchService(dbContext, new NoOpJobSearchProvider());
 
         var result = await service.DeleteAsync([job.Id]);
 
@@ -127,5 +128,13 @@ public class JobSearchServiceTests
             .Options;
 
         return new JobSearchDbContext(options);
+    }
+
+    private sealed class NoOpJobSearchProvider : IJobSearchProvider
+    {
+        public JobSearchProviderKind Provider => JobSearchProviderKind.Adzuna;
+
+        public Task<PublicJobSearchResult> SearchAsync(SearchJobsRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult(new PublicJobSearchResult(0, []));
     }
 }


### PR DESCRIPTION
Closes #55

## Summary
- add admin provider import, JSON import, and JSON export endpoints in the Job Search API
- add admin jobs page controls for new job, import/export, and a provider import dialog matching the API request shape
- update backend docs and extend backend/frontend test coverage for the new workflows

## Validation
- dotnet test services/api/tests/Firefly.Signal.JobSearch.FunctionalTests/Firefly.Signal.JobSearch.FunctionalTests.csproj
- dotnet build services/api/Firefly.Signal.Api.slnx
- npm test -- JobsListView.test.tsx
- npm run lint
- npm run build