### PR TITLE
fix(job-search): export selected jobs only, strip id from export file

### DIFF
--- a/apps/web/src/api/jobs/jobs.api.ts
+++ b/apps/web/src/api/jobs/jobs.api.ts
@@ -1,7 +1,6 @@
 import {
   deleteJson,
   deleteRequest,
-  getBlob,
   getJson,
   postFormData,
   postJson,
@@ -10,6 +9,7 @@ import {
 import type {
   CreateJobRequestDto,
   DeleteJobsResponseDto,
+  ExportJobsRequestDto,
   ExportJobsResponseDto,
   GetJobsPageQueryDto,
   HideJobsResponseDto,
@@ -96,22 +96,11 @@ export async function importJobsFromJson(file: File): Promise<ImportJobsResponse
   return postFormData<ImportJobsResponseDto>("/api/job-search/jobs/import/json", formData);
 }
 
-export async function exportJobs(query: GetJobsPageQueryDto): Promise<ExportJobsResponseDto> {
-  const searchParams = new URLSearchParams();
-
-  appendOptional(searchParams, "keyword", query.keyword);
-  appendOptional(searchParams, "company", query.company);
-  appendOptional(searchParams, "postcode", query.postcode);
-  appendOptional(searchParams, "location", query.location);
-  appendOptional(searchParams, "sourceName", query.sourceName);
-  appendOptional(searchParams, "categoryTag", query.categoryTag);
-
-  if (query.isHidden !== undefined) {
-    searchParams.set("isHidden", String(query.isHidden));
-  }
-
-  const blob = await getBlob(`/api/job-search/jobs/export?${searchParams.toString()}`);
-  return JSON.parse(await blob.text()) as ExportJobsResponseDto;
+export async function exportJobs(request: ExportJobsRequestDto): Promise<ExportJobsResponseDto> {
+  return postJson<ExportJobsResponseDto, ExportJobsRequestDto>(
+    "/api/job-search/jobs/export",
+    request
+  );
 }
 
 function appendOptional(params: URLSearchParams, key: string, value: string | undefined) {

--- a/apps/web/src/api/jobs/jobs.types.ts
+++ b/apps/web/src/api/jobs/jobs.types.ts
@@ -145,8 +145,12 @@ export type ImportJobsResponseDto = {
   failedCount: number;
 };
 
+export type ExportJobsRequestDto = {
+  jobIds: number[];
+};
+
 export type ExportJobsResponseDto = {
   exportedAtUtc: string;
   count: number;
-  jobs: JobDetailsResponseDto[];
+  jobs: JobWriteRequestDto[];
 };

--- a/apps/web/src/features/jobs/components/JobsImportPanel.tsx
+++ b/apps/web/src/features/jobs/components/JobsImportPanel.tsx
@@ -6,6 +6,7 @@ import { Button } from "@mui/material";
 
 type JobsImportPanelProps = {
   isProcessing: boolean;
+  canExport: boolean;
   onCreateJob: () => void;
   onImportProvider: () => void;
   onImportJson: () => void;
@@ -14,6 +15,7 @@ type JobsImportPanelProps = {
 
 export function JobsImportPanel({
   isProcessing,
+  canExport,
   onCreateJob,
   onImportProvider,
   onImportJson,
@@ -32,7 +34,7 @@ export function JobsImportPanel({
             </h2>
             <p className="mt-2 max-w-3xl text-sm text-foreground-secondary">
               Create a manual job, trigger a provider import into PostgreSQL, upload a JSON export
-              back into the catalog, or export the currently filtered stored jobs to JSON.
+              back into the catalog, or select jobs from the list below and export them to JSON.
             </p>
           </div>
 
@@ -50,8 +52,9 @@ export function JobsImportPanel({
               variant="outlined"
               color="inherit"
               startIcon={<DownloadRoundedIcon />}
-              disabled={isProcessing}
+              disabled={isProcessing || !canExport}
               onClick={onExportJson}
+              title={!canExport ? "Select jobs to export" : undefined}
             >
               {isProcessing ? "Working..." : "Export JSON"}
             </Button>

--- a/apps/web/src/features/jobs/views/JobsListView.test.tsx
+++ b/apps/web/src/features/jobs/views/JobsListView.test.tsx
@@ -134,8 +134,47 @@ describe("JobsListView", () => {
     vi.mocked(getJobsPage).mockResolvedValue({
       pageIndex: 0,
       pageSize: 20,
-      totalCount: 0,
-      items: []
+      totalCount: 1,
+      items: [
+        {
+          id: 99,
+          jobRefreshRunId: null,
+          sourceName: "Adzuna",
+          sourceJobId: "adz-99",
+          sourceAdReference: null,
+          title: "Export Test Job",
+          description: "desc",
+          summary: "summary",
+          url: "https://example.com/jobs/99",
+          company: "Acme",
+          companyDisplayName: null,
+          companyCanonicalName: null,
+          postcode: "EC1A 1BB",
+          locationName: "London",
+          locationDisplayName: null,
+          locationAreaJson: null,
+          latitude: null,
+          longitude: null,
+          categoryTag: null,
+          categoryLabel: null,
+          salaryMin: null,
+          salaryMax: null,
+          salaryCurrency: null,
+          salaryIsPredicted: null,
+          contractTime: null,
+          contractType: null,
+          isFullTime: true,
+          isPartTime: false,
+          isPermanent: true,
+          isContract: false,
+          isRemote: false,
+          postedAtUtc: "2025-04-03T10:00:00Z",
+          importedAtUtc: "2025-04-03T12:00:00Z",
+          lastSeenAtUtc: "2025-04-03T12:00:00Z",
+          isHidden: false,
+          rawPayloadJson: "{}"
+        }
+      ]
     });
 
     vi.mocked(importJobsFromProvider).mockResolvedValue({
@@ -200,10 +239,11 @@ describe("JobsListView", () => {
       expect(importJobsFromJson).toHaveBeenCalledWith(file);
     });
 
+    await user.click(screen.getByRole("checkbox", { name: "Select job 99" }));
     await user.click(screen.getByRole("button", { name: "Export JSON" }));
 
     await waitFor(() => {
-      expect(exportJobs).toHaveBeenCalled();
+      expect(exportJobs).toHaveBeenCalledWith({ jobIds: [99] });
       expect(clickSpy).toHaveBeenCalled();
     });
 

--- a/apps/web/src/features/jobs/views/JobsListView.tsx
+++ b/apps/web/src/features/jobs/views/JobsListView.tsx
@@ -222,7 +222,7 @@ export function JobsListView() {
   }
 
   async function handleExport() {
-    if (!isAdmin) {
+    if (!isAdmin || selectedIds.length === 0) {
       return;
     }
 
@@ -231,17 +231,7 @@ export function JobsListView() {
     setActionError(null);
 
     try {
-      const exportResult = await exportJobs({
-        pageIndex,
-        pageSize,
-        keyword: normalizeText(filters.keyword),
-        company: normalizeText(filters.company),
-        postcode: normalizeText(filters.postcode),
-        location: normalizeText(filters.location),
-        sourceName: normalizeText(filters.sourceName),
-        categoryTag: normalizeText(filters.categoryTag),
-        isHidden: mapVisibilityToHiddenFlag(filters.visibility)
-      });
+      const exportResult = await exportJobs({ jobIds: selectedIds });
 
       const blob = new Blob([JSON.stringify(exportResult, null, 2)], {
         type: "application/json"
@@ -272,6 +262,7 @@ export function JobsListView() {
           <>
             <JobsImportPanel
               isProcessing={isProcessing}
+              canExport={selectedIds.length > 0}
               onCreateJob={() => void navigate("/admin/manage-jobs/new")}
               onExportJson={() => void handleExport()}
               onImportJson={() => fileInputRef.current?.click()}

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Application/JobContracts.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Application/JobContracts.cs
@@ -52,6 +52,7 @@ public sealed record GetJobsPageRequest(
     bool? IsHidden = false);
 
 public sealed record ExportJobsRequest(
+    IReadOnlyList<long>? JobIds = null,
     string? Keyword = null,
     string? Company = null,
     string? Postcode = null,
@@ -177,4 +178,4 @@ public sealed record ImportJobsResponse(
 public sealed record ExportJobsResponse(
     DateTime ExportedAtUtc,
     int Count,
-    IReadOnlyList<JobDetailsResponse> Jobs);
+    IReadOnlyList<CreateJobRequest> Jobs);

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Endpoints/JobSearchEndpoints.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Endpoints/JobSearchEndpoints.cs
@@ -27,7 +27,7 @@ public static class JobSearchEndpoints
         adminGroup.MapPost("/import/provider", ImportFromProviderAsync);
         adminGroup.MapPost("/import/json", ImportFromJsonAsync)
             .DisableAntiforgery();
-        adminGroup.MapGet("/export", ExportAsync);
+        adminGroup.MapPost("/export", ExportAsync);
 
         return endpoints;
     }
@@ -204,26 +204,11 @@ public static class JobSearchEndpoints
     }
 
     private static async Task<FileContentHttpResult> ExportAsync(
-        [FromQuery] string? keyword,
-        [FromQuery] string? company,
-        [FromQuery] string? postcode,
-        [FromQuery] string? location,
-        [FromQuery] string? sourceName,
-        [FromQuery] string? categoryTag,
-        [FromQuery] bool? isHidden,
+        [FromBody] ExportJobsRequest request,
         [FromServices] IJobSearchService service,
         CancellationToken cancellationToken)
     {
-        var export = await service.ExportAsync(
-            new ExportJobsRequest(
-                keyword,
-                company,
-                postcode,
-                location,
-                sourceName,
-                categoryTag,
-                isHidden),
-            cancellationToken);
+        var export = await service.ExportAsync(request, cancellationToken);
 
         var content = JsonSerializer.SerializeToUtf8Bytes(export, new JsonSerializerOptions(JsonSerializerDefaults.Web)
         {

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/Services/DbJobSearchService.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/Services/DbJobSearchService.cs
@@ -46,7 +46,16 @@ public sealed class DbJobSearchService(
 
     public async Task<ExportJobsResponse> ExportAsync(ExportJobsRequest request, CancellationToken cancellationToken = default)
     {
-        var jobs = await ApplyFilters(dbContext.Jobs.AsNoTracking(), new GetJobsPageRequest(
+        IQueryable<JobPosting> query;
+
+        if (request.JobIds is { Count: > 0 })
+        {
+            var ids = request.JobIds.Distinct().ToArray();
+            query = dbContext.Jobs.AsNoTracking().Where(x => ids.Contains(x.Id));
+        }
+        else
+        {
+            query = ApplyFilters(dbContext.Jobs.AsNoTracking(), new GetJobsPageRequest(
                 0,
                 int.MaxValue,
                 request.Keyword,
@@ -55,10 +64,13 @@ public sealed class DbJobSearchService(
                 request.Location,
                 request.SourceName,
                 request.CategoryTag,
-                request.IsHidden))
+                request.IsHidden));
+        }
+
+        var jobs = await query
             .OrderByDescending(x => x.PostedAtUtc)
             .ThenByDescending(x => x.Id)
-            .Select(ToResponse())
+            .Select(ToExportEntry())
             .ToListAsync(cancellationToken);
 
         return new ExportJobsResponse(DateTime.UtcNow, jobs.Count, jobs);
@@ -465,6 +477,44 @@ public sealed class DbJobSearchService(
             request.LastSeenAtUtc == default ? DateTime.UtcNow : request.LastSeenAtUtc,
             request.IsHidden,
             request.RawPayloadJson);
+
+    private static Expression<Func<JobPosting, CreateJobRequest>> ToExportEntry()
+        => job => new CreateJobRequest(
+            job.JobRefreshRunId,
+            job.SourceName,
+            job.SourceJobId,
+            job.SourceAdReference,
+            job.Title,
+            job.Description,
+            job.Summary,
+            job.Url,
+            job.Company,
+            job.CompanyDisplayName,
+            job.CompanyCanonicalName,
+            job.Postcode,
+            job.LocationName,
+            job.LocationDisplayName,
+            job.LocationAreaJson,
+            job.Latitude,
+            job.Longitude,
+            job.CategoryTag,
+            job.CategoryLabel,
+            job.SalaryMin,
+            job.SalaryMax,
+            job.SalaryCurrency,
+            job.SalaryIsPredicted,
+            job.ContractTime,
+            job.ContractType,
+            job.IsFullTime,
+            job.IsPartTime,
+            job.IsPermanent,
+            job.IsContract,
+            job.IsRemote,
+            job.PostedAtUtc,
+            job.ImportedAtUtc,
+            job.LastSeenAtUtc,
+            job.IsHidden,
+            job.RawPayloadJson);
 
     private static Expression<Func<JobPosting, JobDetailsResponse>> ToResponse()
         => job => new JobDetailsResponse(

--- a/services/api/tests/Firefly.Signal.JobSearch.FunctionalTests/JobSearchApiTests.cs
+++ b/services/api/tests/Firefly.Signal.JobSearch.FunctionalTests/JobSearchApiTests.cs
@@ -110,7 +110,7 @@ public class JobSearchApiTests
         using var client = factory.CreateClient();
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateAccessToken());
 
-        var response = await client.GetAsync("/api/job-search/jobs/export");
+        var response = await client.PostAsJsonAsync("/api/job-search/jobs/export", new ExportJobsRequest());
 
         response.EnsureSuccessStatusCode();
         Assert.AreEqual("application/json", response.Content.Headers.ContentType?.MediaType);


### PR DESCRIPTION
## Summary

- Export now requires selecting jobs from the list — the `Export JSON` button is disabled until at least one job is checked
- Exported JSON no longer contains `id` fields (projects to `CreateJobRequest` shape), making files safe to re-import without ID collisions
- Export endpoint changed from `GET` to `POST` to carry the `jobIds` list in the request body

## Changes

**Backend**
- `ExportJobsRequest` — added `IReadOnlyList<long>? JobIds`
- `DbJobSearchService.ExportAsync` — filters by `JobIds` when provided; new `ToExportEntry()` projection maps to `CreateJobRequest` (no `Id`)
- `JobSearchEndpoints` — `/export` changed from `MapGet` → `MapPost`, reads `[FromBody] ExportJobsRequest`
- `ExportJobsResponse.Jobs` — changed from `IReadOnlyList<JobDetailsResponse>` to `IReadOnlyList<CreateJobRequest>`

**Frontend**
- `jobs.types.ts` — added `ExportJobsRequestDto { jobIds: number[] }`; `ExportJobsResponseDto.jobs` now typed as `JobWriteRequestDto[]`
- `jobs.api.ts` — `exportJobs` posts `{ jobIds }` instead of filter query params
- `JobsImportPanel` — added `canExport` prop; Export JSON button disabled when `false`
- `JobsListView` — `handleExport` passes `selectedIds`; `canExport={selectedIds.length > 0}`

## Test plan

- [ ] Select one or more jobs → Export JSON button enables
- [ ] Click Export JSON → file downloads containing only the selected jobs, with no `id` field on each entry
- [ ] With no jobs selected → Export JSON button is disabled (tooltip: "Select jobs to export")
- [ ] Import the exported file → jobs created with new DB-assigned IDs

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)