### PR TITLE
fix(job-search): align provider import contract (#93)

### DIFF
--- a/apps/web/src/api/jobs/jobs.types.ts
+++ b/apps/web/src/api/jobs/jobs.types.ts
@@ -115,27 +115,17 @@ export type IdBatchRequestDto = {
 };
 
 export type ImportJobsFromProviderRequestDto = {
-  postcode: string;
-  keyword: string;
   pageIndex?: number;
   pageSize?: number;
+  where?: string;
+  keyword?: string;
+  distanceKilometers?: number;
+  maxDaysOld?: number;
+  category?: string;
   provider?: "Adzuna";
   excludedKeyword?: string;
-  distanceKilometers?: number;
-  category?: string;
   salaryMin?: number;
   salaryMax?: number;
-  fullTime?: boolean;
-  partTime?: boolean;
-  permanent?: boolean;
-  contract?: boolean;
-  sortBy?: string;
-  maxDaysOld?: number;
-  company?: string;
-  titleOnly?: boolean;
-  location0?: string;
-  location1?: string;
-  location2?: string;
 };
 
 export type ImportJobsResponseDto = {

--- a/apps/web/src/features/jobs/components/JobsImportProviderDialog.tsx
+++ b/apps/web/src/features/jobs/components/JobsImportProviderDialog.tsx
@@ -1,27 +1,17 @@
-import { Checkbox, Dialog, DialogActions, DialogContent, DialogTitle, Button, FormControlLabel, MenuItem, TextField } from "@mui/material";
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, MenuItem, TextField } from "@mui/material";
 
 export type JobsImportProviderFormValues = {
-  postcode: string;
+  where: string;
   keyword: string;
   pageIndex: string;
   pageSize: string;
   provider: "Adzuna";
   excludedKeyword: string;
   distanceKilometers: string;
+  maxDaysOld: string;
   category: string;
   salaryMin: string;
   salaryMax: string;
-  fullTime: "" | "true" | "false";
-  partTime: "" | "true" | "false";
-  permanent: "" | "true" | "false";
-  contract: "" | "true" | "false";
-  sortBy: string;
-  maxDaysOld: string;
-  company: string;
-  titleOnly: boolean;
-  location0: string;
-  location1: string;
-  location2: string;
 };
 
 type JobsImportProviderDialogProps = {
@@ -47,15 +37,15 @@ export function JobsImportProviderDialog({
       <DialogContent>
         <div className="grid gap-4 pt-2 md:grid-cols-2">
           <TextField
-            label="Postcode"
+            label="Where"
             required
             size="small"
-            value={values.postcode}
-            onChange={(event) => onChange({ ...values, postcode: event.target.value })}
+            helperText="Location or postcode, for example London or SW1A 1AA."
+            value={values.where}
+            onChange={(event) => onChange({ ...values, where: event.target.value })}
           />
           <TextField
             label="Keyword"
-            required
             size="small"
             value={values.keyword}
             onChange={(event) => onChange({ ...values, keyword: event.target.value })}
@@ -99,6 +89,13 @@ export function JobsImportProviderDialog({
             onChange={(event) => onChange({ ...values, distanceKilometers: event.target.value })}
           />
           <TextField
+            label="Max days old"
+            size="small"
+            type="number"
+            value={values.maxDaysOld}
+            onChange={(event) => onChange({ ...values, maxDaysOld: event.target.value })}
+          />
+          <TextField
             label="Category"
             size="small"
             value={values.category}
@@ -118,99 +115,7 @@ export function JobsImportProviderDialog({
             value={values.salaryMax}
             onChange={(event) => onChange({ ...values, salaryMax: event.target.value })}
           />
-          <TextField
-            select
-            label="Full time"
-            size="small"
-            value={values.fullTime}
-            onChange={(event) => onChange({ ...values, fullTime: event.target.value as JobsImportProviderFormValues["fullTime"] })}
-          >
-            <MenuItem value="">Any</MenuItem>
-            <MenuItem value="true">Yes</MenuItem>
-            <MenuItem value="false">No</MenuItem>
-          </TextField>
-          <TextField
-            select
-            label="Part time"
-            size="small"
-            value={values.partTime}
-            onChange={(event) => onChange({ ...values, partTime: event.target.value as JobsImportProviderFormValues["partTime"] })}
-          >
-            <MenuItem value="">Any</MenuItem>
-            <MenuItem value="true">Yes</MenuItem>
-            <MenuItem value="false">No</MenuItem>
-          </TextField>
-          <TextField
-            select
-            label="Permanent"
-            size="small"
-            value={values.permanent}
-            onChange={(event) => onChange({ ...values, permanent: event.target.value as JobsImportProviderFormValues["permanent"] })}
-          >
-            <MenuItem value="">Any</MenuItem>
-            <MenuItem value="true">Yes</MenuItem>
-            <MenuItem value="false">No</MenuItem>
-          </TextField>
-          <TextField
-            select
-            label="Contract"
-            size="small"
-            value={values.contract}
-            onChange={(event) => onChange({ ...values, contract: event.target.value as JobsImportProviderFormValues["contract"] })}
-          >
-            <MenuItem value="">Any</MenuItem>
-            <MenuItem value="true">Yes</MenuItem>
-            <MenuItem value="false">No</MenuItem>
-          </TextField>
-          <TextField
-            label="Sort by"
-            size="small"
-            value={values.sortBy}
-            onChange={(event) => onChange({ ...values, sortBy: event.target.value })}
-          />
-          <TextField
-            label="Max days old"
-            size="small"
-            type="number"
-            value={values.maxDaysOld}
-            onChange={(event) => onChange({ ...values, maxDaysOld: event.target.value })}
-          />
-          <TextField
-            label="Company"
-            size="small"
-            value={values.company}
-            onChange={(event) => onChange({ ...values, company: event.target.value })}
-          />
-          <TextField
-            label="Location 0"
-            size="small"
-            value={values.location0}
-            onChange={(event) => onChange({ ...values, location0: event.target.value })}
-          />
-          <TextField
-            label="Location 1"
-            size="small"
-            value={values.location1}
-            onChange={(event) => onChange({ ...values, location1: event.target.value })}
-          />
-          <TextField
-            label="Location 2"
-            size="small"
-            value={values.location2}
-            onChange={(event) => onChange({ ...values, location2: event.target.value })}
-          />
         </div>
-
-        <FormControlLabel
-          className="mt-4"
-          control={
-            <Checkbox
-              checked={values.titleOnly}
-              onChange={(event) => onChange({ ...values, titleOnly: event.target.checked })}
-            />
-          }
-          label="Search title only"
-        />
       </DialogContent>
       <DialogActions sx={{ px: 3, pb: 3 }}>
         <Button onClick={onClose} color="inherit" disabled={isSubmitting}>

--- a/apps/web/src/features/jobs/views/JobsListView.test.tsx
+++ b/apps/web/src/features/jobs/views/JobsListView.test.tsx
@@ -211,16 +211,21 @@ describe("JobsListView", () => {
 
     await user.click(screen.getByRole("button", { name: "Import from provider" }));
     await user.type(screen.getByRole("textbox", { name: "Keyword" }), "frontend engineer");
-    await user.type(screen.getByRole("textbox", { name: "Postcode" }), "SW1A 1AA");
+    const whereInput = screen.getByRole("textbox", { name: "Where" });
+    await user.clear(whereInput);
+    await user.type(whereInput, "SW1A 1AA");
     await user.click(screen.getByRole("button", { name: "Run import" }));
 
     await waitFor(() => {
       expect(importJobsFromProvider).toHaveBeenCalledWith(
         expect.objectContaining({
+          where: "SW1A 1AA",
           keyword: "frontend engineer",
-          postcode: "SW1A 1AA",
-          pageIndex: 0,
-          pageSize: 20,
+          pageIndex: 1,
+          pageSize: 50,
+          distanceKilometers: 5,
+          maxDaysOld: 30,
+          category: "it-jobs",
           provider: "Adzuna"
         })
       );

--- a/apps/web/src/features/jobs/views/JobsListView.tsx
+++ b/apps/web/src/features/jobs/views/JobsListView.tsx
@@ -43,27 +43,17 @@ const emptyFilters: JobsListFilters = {
 
 const defaultPageSize = 20;
 const defaultImportForm: JobsImportProviderFormValues = {
-  postcode: "",
+  where: "london",
   keyword: "",
-  pageIndex: "0",
-  pageSize: "20",
+  pageIndex: "1",
+  pageSize: "50",
   provider: "Adzuna",
   excludedKeyword: "",
-  distanceKilometers: "",
-  category: "",
+  distanceKilometers: "5",
+  maxDaysOld: "30",
+  category: "it-jobs",
   salaryMin: "",
-  salaryMax: "",
-  fullTime: "",
-  partTime: "",
-  permanent: "",
-  contract: "",
-  sortBy: "",
-  maxDaysOld: "",
-  company: "",
-  titleOnly: false,
-  location0: "",
-  location1: "",
-  location2: ""
+  salaryMax: ""
 };
 
 export function JobsListView() {
@@ -174,11 +164,10 @@ export function JobsListView() {
       return;
     }
 
-    const keyword = importForm.keyword.trim();
-    const postcode = importForm.postcode.trim();
-    if (!keyword || !postcode) {
+    const where = importForm.where.trim();
+    if (!where) {
       setActionMessage(null);
-      setActionError("Enter both a keyword and postcode before importing from the provider.");
+      setActionError("Enter a location or postcode before importing from the provider.");
       return;
     }
 
@@ -187,7 +176,7 @@ export function JobsListView() {
     setActionError(null);
 
     try {
-      const result = await importJobsFromProvider(buildImportRequest(importForm, keyword, postcode));
+      const result = await importJobsFromProvider(buildImportRequest(importForm, where));
       setActionMessage(`Imported ${result.importedCount} jobs from ${result.source}.`);
       setIsImportDialogOpen(false);
       await execute(pageIndex, pageSize, filters);
@@ -400,41 +389,22 @@ function parseOptionalNumber(value: string): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
-function parseOptionalBoolean(value: "" | "true" | "false"): boolean | undefined {
-  if (value === "") {
-    return undefined;
-  }
-
-  return value === "true";
-}
-
 function buildImportRequest(
   values: JobsImportProviderFormValues,
-  keyword: string,
-  postcode: string
+  where: string
 ): ImportJobsFromProviderRequestDto {
   return {
-    postcode,
-    keyword,
-    pageIndex: parseOptionalNumber(values.pageIndex) ?? 0,
-    pageSize: parseOptionalNumber(values.pageSize) ?? 20,
+    pageIndex: parseOptionalNumber(values.pageIndex) ?? 1,
+    pageSize: parseOptionalNumber(values.pageSize) ?? 50,
+    where,
+    keyword: normalizeText(values.keyword),
+    distanceKilometers: parseOptionalNumber(values.distanceKilometers) ?? 5,
+    maxDaysOld: parseOptionalNumber(values.maxDaysOld) ?? 30,
+    category: normalizeText(values.category) ?? "it-jobs",
     provider: values.provider,
     excludedKeyword: normalizeText(values.excludedKeyword),
-    distanceKilometers: parseOptionalNumber(values.distanceKilometers),
-    category: normalizeText(values.category),
     salaryMin: parseOptionalNumber(values.salaryMin),
-    salaryMax: parseOptionalNumber(values.salaryMax),
-    fullTime: parseOptionalBoolean(values.fullTime),
-    partTime: parseOptionalBoolean(values.partTime),
-    permanent: parseOptionalBoolean(values.permanent),
-    contract: parseOptionalBoolean(values.contract),
-    sortBy: normalizeText(values.sortBy),
-    maxDaysOld: parseOptionalNumber(values.maxDaysOld),
-    company: normalizeText(values.company),
-    titleOnly: values.titleOnly,
-    location0: normalizeText(values.location0),
-    location1: normalizeText(values.location1),
-    location2: normalizeText(values.location2)
+    salaryMax: parseOptionalNumber(values.salaryMax)
   };
 }
 

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Application/JobContracts.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Application/JobContracts.cs
@@ -62,27 +62,17 @@ public sealed record ExportJobsRequest(
     bool? IsHidden = null);
 
 public sealed record ImportJobsFromProviderRequest(
-    string Postcode,
-    string Keyword,
-    int PageIndex = 0,
-    int PageSize = 20,
+    int PageIndex = 1,
+    int PageSize = 50,
+    string Where = "london", //location or postcode
+    string? Keyword = null, 
+    int DistanceKilometers = 5,
+    int MaxDaysOld = 30, // days old of a job post
+    string Category = "it-jobs",
     JobSearchProviderKind Provider = JobSearchProviderKind.Adzuna,
     string? ExcludedKeyword = null,
-    int? DistanceKilometers = null,
-    string? Category = null,
     decimal? SalaryMin = null,
-    decimal? SalaryMax = null,
-    bool? FullTime = null,
-    bool? PartTime = null,
-    bool? Permanent = null,
-    bool? Contract = null,
-    string? SortBy = null,
-    int? MaxDaysOld = null,
-    string? Company = null,
-    bool TitleOnly = false,
-    string? Location0 = null,
-    string? Location1 = null,
-    string? Location2 = null);
+    decimal? SalaryMax = null);
 
 public sealed record CreateJobRequest(
     long? JobRefreshRunId,

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Application/SearchJobsRequest.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Application/SearchJobsRequest.cs
@@ -1,8 +1,8 @@
 namespace Firefly.Signal.JobSearch.Application;
 
 public sealed record SearchJobsRequest(
-    string Postcode,
-    string Keyword,
+    string Location,
+    string? Keyword,
     int PageIndex = 0,
     int PageSize = 20,
     JobSearchProviderKind Provider = JobSearchProviderKind.Adzuna,

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/JobSearchProviders/Adzuna/AdzunaJobSearchRequest.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/JobSearchProviders/Adzuna/AdzunaJobSearchRequest.cs
@@ -8,7 +8,7 @@ public sealed record AdzunaJobSearchRequest(
     [property: JsonPropertyName("results_per_page")]
     int ResultsPerPage,
     [property: JsonPropertyName("what")]
-    string What,
+    string? What,
     [property: JsonPropertyName("what_exclude")]
     string? WhatExclude,
     [property: JsonPropertyName("where")]

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/JobSearchProviders/Adzuna/AdzunaJobSearchRequestMapper.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/JobSearchProviders/Adzuna/AdzunaJobSearchRequestMapper.cs
@@ -10,7 +10,7 @@ public sealed class AdzunaJobSearchRequestMapper
             request.PageSize,
             request.Keyword,
             request.ExcludedKeyword,
-            request.Postcode,
+            request.Location,
             request.DistanceKilometers,
             request.Category,
             request.SalaryMin,

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/JobSearchProviders/Adzuna/MockAdzunaJobSearchProvider.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/JobSearchProviders/Adzuna/MockAdzunaJobSearchProvider.cs
@@ -10,12 +10,14 @@ public sealed class MockAdzunaJobSearchProvider : IJobSearchProvider
 
     public Task<PublicJobSearchResult> SearchAsync(SearchJobsRequest request, CancellationToken cancellationToken = default)
     {
+        var keyword = string.IsNullOrWhiteSpace(request.Keyword) ? "Software" : request.Keyword.Trim();
+
         JobPosting[] jobs =
         [
             JobPosting.Create(
-                $"{request.Keyword} Developer",
+                $"{keyword} Developer",
                 "Mock North Star Tech",
-                request.Postcode,
+                request.Location,
                 "London",
                 "Mock Adzuna result for local development and rate-limit-safe testing.",
                 "https://example.com/jobs/mock-adzuna-1",
@@ -23,9 +25,9 @@ public sealed class MockAdzunaJobSearchProvider : IJobSearchProvider
                 false,
                 new DateTime(2026, 4, 1, 9, 0, 0, DateTimeKind.Utc)),
             JobPosting.Create(
-                $"{request.Keyword} Platform Engineer",
+                $"{keyword} Platform Engineer",
                 "Mock Cloud Rail",
-                request.Postcode,
+                request.Location,
                 "Manchester",
                 "Mock Adzuna result for provider wiring and UI verification.",
                 "https://example.com/jobs/mock-adzuna-2",

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/Services/DbJobSearchService.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Infrastructure/Services/DbJobSearchService.cs
@@ -175,7 +175,7 @@ public sealed class DbJobSearchService(
         CancellationToken cancellationToken = default)
     {
         var providerRequest = new SearchJobsRequest(
-            request.Postcode,
+            request.Where,
             request.Keyword,
             request.PageIndex,
             request.PageSize,
@@ -185,17 +185,7 @@ public sealed class DbJobSearchService(
             request.Category,
             request.SalaryMin,
             request.SalaryMax,
-            request.FullTime,
-            request.PartTime,
-            request.Permanent,
-            request.Contract,
-            request.SortBy,
-            request.MaxDaysOld,
-            request.Company,
-            request.TitleOnly,
-            request.Location0,
-            request.Location1,
-            request.Location2);
+            MaxDaysOld: request.MaxDaysOld);
 
         var filtersJson = JsonSerializer.Serialize(request, JsonOptions);
         var refreshRun = JobRefreshRun.Start(

--- a/services/api/src/Firefly.Signal.JobSearch.Api/Program.cs
+++ b/services/api/src/Firefly.Signal.JobSearch.Api/Program.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json.Serialization;
 using Firefly.Signal.JobSearch.Application;
 using Firefly.Signal.EventBus;
 using Firefly.Signal.EventBusRabbitMQ;
@@ -18,6 +19,10 @@ var builder = WebApplication.CreateBuilder(args);
 builder.AddFireflyServiceDefaults();
 builder.AddDefaultOpenApi();
 builder.Services.AddProblemDetails();
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
+});
 builder.Services.Configure<JwtOptions>(builder.Configuration.GetSection(JwtOptions.SectionName));
 builder.Services.Configure<AdzunaOptions>(builder.Configuration.GetSection(AdzunaOptions.SectionName));
 builder.Services.AddDbContext<JobSearchDbContext>(options =>

--- a/services/api/tests/Firefly.Signal.JobSearch.FunctionalTests/JobSearchApiTests.cs
+++ b/services/api/tests/Firefly.Signal.JobSearch.FunctionalTests/JobSearchApiTests.cs
@@ -103,6 +103,28 @@ public class JobSearchApiTests
     }
 
     [TestMethod]
+    public async Task Provider_import_accepts_string_enum_provider_from_json()
+    {
+        await using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateAccessToken());
+
+        var response = await client.PostAsJsonAsync("/api/job-search/jobs/import/provider", new
+        {
+            postcode = "SW1A 1AA",
+            keyword = "platform",
+            pageSize = 20,
+            provider = "Adzuna"
+        });
+
+        response.EnsureSuccessStatusCode();
+        var payload = await response.Content.ReadFromJsonAsync<ImportJobsResponse>();
+        Assert.IsNotNull(payload);
+        Assert.AreEqual("Adzuna", payload.Source);
+        Assert.AreEqual(2, payload.ImportedCount);
+    }
+
+    [TestMethod]
     public async Task Export_returns_json_file_for_admin()
     {
         await using var factory = CreateFactory();


### PR DESCRIPTION
## Summary
- align the job search API provider import contract with the updated backend request shape
- update the admin jobs import dialog and request builder to send the new payload
- keep the mock provider and request mappers in sync with the renamed location field

## Why
- the backend contract changed and the admin import flow needed matching UI and mapper updates to keep provider imports working

## Validation
- dotnet test services/api/tests/Firefly.Signal.JobSearch.FunctionalTests/Firefly.Signal.JobSearch.FunctionalTests.csproj
- npm test -- --run src/features/jobs/views/JobsListView.test.tsx

## Assumptions
- issue #93 remains open because additional blocked follow-up work still needs a separate issue
- the current UI should follow the new backend defaults for page index, page size, distance, days old, and category

## Risks
- live provider behavior still depends on the separate blocked follow-up work that prompted keeping #93 open

Refs #93