### PR TITLE
fix(backend): validate api startup DI registrations (#104)

### DIFF
--- a/services/api/Firefly.Signal.Api.slnx
+++ b/services/api/Firefly.Signal.Api.slnx
@@ -11,6 +11,7 @@
     <Project Path="src/Firefly.Signal.ServiceDefaults/Firefly.Signal.ServiceDefaults.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Firefly.Signal.Api.UnitTests/Firefly.Signal.Api.UnitTests.csproj" />
     <Project Path="tests/Firefly.Signal.Identity.FunctionalTests/Firefly.Signal.Identity.FunctionalTests.csproj" />
     <Project Path="tests/Firefly.Signal.Identity.UnitTests/Firefly.Signal.Identity.UnitTests.csproj" />
     <Project Path="tests/Firefly.Signal.JobSearch.FunctionalTests/Firefly.Signal.JobSearch.FunctionalTests.csproj" />

--- a/services/api/src/Firefly.Signal.SharedKernel/Extensions/ExceptionHandlingExtensions.cs
+++ b/services/api/src/Firefly.Signal.SharedKernel/Extensions/ExceptionHandlingExtensions.cs
@@ -7,10 +7,7 @@ namespace Firefly.Signal.SharedKernel.Extensions;
 public static class ExceptionHandlingExtensions
 {
     public static IServiceCollection AddFireflyExceptionHandling(this IServiceCollection services)
-    {
-        services.AddTransient<GlobalExceptionHandlerMiddleware>();
-        return services;
-    }
+        => services;
 
     public static IApplicationBuilder UseFireflyExceptionHandling(this IApplicationBuilder app)
         => app.UseMiddleware<GlobalExceptionHandlerMiddleware>();

--- a/services/api/tests/Firefly.Signal.Api.UnitTests/Firefly.Signal.Api.UnitTests.csproj
+++ b/services/api/tests/Firefly.Signal.Api.UnitTests/Firefly.Signal.Api.UnitTests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Firefly.Signal.Ai.Api\Firefly.Signal.Ai.Api.csproj" />
+    <ProjectReference Include="..\..\src\Firefly.Signal.Gateway.Api\Firefly.Signal.Gateway.Api.csproj" />
+    <ProjectReference Include="..\..\src\Firefly.Signal.Identity.Api\Firefly.Signal.Identity.Api.csproj" />
+    <ProjectReference Include="..\..\src\Firefly.Signal.JobSearch.Api\Firefly.Signal.JobSearch.Api.csproj" />
+    <ProjectReference Include="..\..\src\Firefly.Signal.ServiceDefaults\Firefly.Signal.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\..\src\Firefly.Signal.SharedKernel\Firefly.Signal.SharedKernel.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/api/tests/Firefly.Signal.Api.UnitTests/Properties/AssemblyInfo.cs
+++ b/services/api/tests/Firefly.Signal.Api.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[assembly: DoNotParallelize]

--- a/services/api/tests/Firefly.Signal.Api.UnitTests/Startup/ApiHostDependencyInjectionTests.cs
+++ b/services/api/tests/Firefly.Signal.Api.UnitTests/Startup/ApiHostDependencyInjectionTests.cs
@@ -1,0 +1,91 @@
+using System.Reflection;
+using Firefly.Signal.ServiceDefaults;
+using Firefly.Signal.SharedKernel.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Firefly.Signal.Api.UnitTests.Startup;
+
+[TestClass]
+public sealed class ApiHostDependencyInjectionTests
+{
+    public static IEnumerable<object[]> ApiDescriptors()
+    {
+        yield return
+        [
+            "Firefly.Signal.Ai.Api",
+            "Firefly.Signal.Ai.Api.Extensions.ApplicationServiceExtensions"
+        ];
+
+        yield return
+        [
+            "Firefly.Signal.Gateway.Api",
+            "Firefly.Signal.Gateway.Api.Extensions.ApplicationServiceExtensions"
+        ];
+
+        yield return
+        [
+            "Firefly.Signal.Identity.Api",
+            "Firefly.Signal.Identity.Api.Extensions.ApplicationServiceExtensions"
+        ];
+
+        yield return
+        [
+            "Firefly.Signal.JobSearch.Api",
+            "Firefly.Signal.JobSearch.Api.Extensions.ApplicationServiceExtensions"
+        ];
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(ApiDescriptors))]
+    public void AddApplicationServices_RegistersServicesThatValidateOnBuild(
+        string assemblyName,
+        string extensionTypeName)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            ApplicationName = assemblyName,
+            EnvironmentName = "Testing"
+        });
+
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Testing:DatabaseName"] = $"{assemblyName}-tests",
+            ["Jwt:SigningKey"] = "firefly-signal-dev-signing-key-please-change",
+            ["UserDocumentStorage:AllowedContentTypes:0"] = "application/pdf",
+            ["UserDocumentStorage:AllowedFileExtensions:0"] = ".pdf"
+        });
+
+        builder.AddFireflyServiceDefaults();
+        InvokeAddApplicationServices(builder, assemblyName, extensionTypeName);
+        builder.Services.AddProblemDetails();
+        builder.Services.AddFireflyExceptionHandling();
+        builder.AddDefaultOpenApi();
+
+        using var serviceProvider = builder.Services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        Assert.IsNotNull(serviceProvider);
+    }
+
+    private static void InvokeAddApplicationServices(
+        WebApplicationBuilder builder,
+        string assemblyName,
+        string extensionTypeName)
+    {
+        var assembly = Assembly.Load(assemblyName);
+        var extensionType = assembly.GetType(extensionTypeName, throwOnError: true)!;
+        var method = extensionType.GetMethod(
+            "AddApplicationServices",
+            BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+
+        Assert.IsNotNull(method, $"Could not find AddApplicationServices on {extensionTypeName}.");
+
+        method.Invoke(null, [builder]);
+    }
+}


### PR DESCRIPTION
Closes #104.

## Summary
- remove the invalid DI registration for `GlobalExceptionHandlerMiddleware` so it is only activated by the ASP.NET Core middleware pipeline
- add startup validation tests that build each API host service collection with `ValidateOnBuild`
- add the new backend API startup test project to the solution

## Validation
- `dotnet test services/api/tests/Firefly.Signal.Api.UnitTests/Firefly.Signal.Api.UnitTests.csproj`
- `dotnet test services/api/tests/Firefly.Signal.Identity.FunctionalTests/Firefly.Signal.Identity.FunctionalTests.csproj`
- `dotnet test services/api/tests/Firefly.Signal.JobSearch.FunctionalTests/Firefly.Signal.JobSearch.FunctionalTests.csproj`
- `dotnet test services/api/Firefly.Signal.Api.slnx`

## Notes
- the new tests cover `Firefly.Signal.Ai.Api`, `Firefly.Signal.Gateway.Api`, `Firefly.Signal.Identity.Api`, and `Firefly.Signal.JobSearch.Api`
- this specifically guards against unresolved DI registrations during host startup, including the `RequestDelegate` middleware activation error