### PR TITLE
chore(workflow): make issue worktrees VS Code-friendly (#114)

### DIFF
--- a/.agents/skills/git-issue/SKILL.md
+++ b/.agents/skills/git-issue/SKILL.md
@@ -70,14 +70,15 @@ Run all of these in one chat session before handing back to the developer.
    If the branch already exists, check it out and push any pending commits.
 5. Create a git worktree so parallel agents can work on the same server without collision:
    ```
-   git worktree add ../firefly-worktrees/issue-<number>-<title> issue-<number>-<title>
+   mkdir -p worktrees
+   git worktree add worktrees/issue-<number>-<title> issue-<number>-<title>
    ```
-   Worktrees live at `../firefly-worktrees/<branch-name>` (sibling to the main repo).
+   Worktrees live at `worktrees/<branch-name>` inside the repo.
 6. Read `AGENTS.md` and relevant source files to understand existing patterns.
 7. Enrich the issue body — **append below any existing description, never overwrite it**. Fill in `Goal`, `Scope`, `Acceptance Criteria`, and `Constraints` based on what you learned from the repo.
 8. Post a comment with the branch name and worktree path:
    ```
-   gh issue comment <number> --body "Branch: issue-<number>-<title>\nWorktree: ../firefly-worktrees/issue-<number>-<title>"
+   gh issue comment <number> --body "Branch: issue-<number>-<title>\nWorktree: worktrees/issue-<number>-<title>"
    ```
 9. Post a second comment with a numbered implementation plan:
    ```
@@ -85,5 +86,5 @@ Run all of these in one chat session before handing back to the developer.
    ```
 
 ## Further Rounds — Implementation
-- Work inside the worktree: `../firefly-worktrees/<branch-name>`.
+- Work inside the worktree: `worktrees/<branch-name>`.
 - Commit and push before ending every chat session so the developer can review progress.

--- a/.agents/skills/git-pr/SKILL.md
+++ b/.agents/skills/git-pr/SKILL.md
@@ -58,8 +58,8 @@ Run all of these in one chat session after the developer approves the branch.
 1. Read this skill (`git-pr`).
 2. Rebase onto the latest `main`:
    ```
-   git -C ../firefly-worktrees/<branch> fetch origin
-   git -C ../firefly-worktrees/<branch> rebase origin/main
+   git -C worktrees/<branch> fetch origin
+   git -C worktrees/<branch> rebase origin/main
    ```
 3. Create the PR from the worktree:
    ```
@@ -77,7 +77,7 @@ Run all of these in one chat session after the developer approves the branch.
    ```
 6. Remove the worktree:
    ```
-   git worktree remove ../firefly-worktrees/<branch>
+   git worktree remove worktrees/<branch>
    ```
 7. Delete the local branch if it still exists:
    ```

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ Thumbs.db
 
 # Editors
 .idea/
-.vscode/
 *.suo
 *.user
 *.userosscache

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,80 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Web App (Local Env)",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npm run dev",
+      "cwd": "${workspaceFolder}/apps/web"
+    },
+    {
+      "name": "Web App (Prod Env)",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "VITE_API_BASE_URL=https://api-signal.firefly-ai.co.uk npm run dev -- --mode production",
+      "cwd": "${workspaceFolder}/apps/web"
+    },
+    {
+      "name": "Gateway API",
+      "type": "coreclr",
+      "request": "launch",
+      "program": "${workspaceFolder}/services/api/src/Firefly.Signal.Gateway.Api/bin/Debug/net10.0/Firefly.Signal.Gateway.Api.dll",
+      "cwd": "${workspaceFolder}/services/api/src/Firefly.Signal.Gateway.Api",
+      "launchSettingsFilePath": "${workspaceFolder}/services/api/src/Firefly.Signal.Gateway.Api/Properties/launchSettings.json",
+      "launchSettingsProfile": "http"
+    },
+    {
+      "name": "Identity API",
+      "type": "coreclr",
+      "request": "launch",
+      "program": "${workspaceFolder}/services/api/src/Firefly.Signal.Identity.Api/bin/Debug/net10.0/Firefly.Signal.Identity.Api.dll",
+      "cwd": "${workspaceFolder}/services/api/src/Firefly.Signal.Identity.Api",
+      "launchSettingsFilePath": "${workspaceFolder}/services/api/src/Firefly.Signal.Identity.Api/Properties/launchSettings.json",
+      "launchSettingsProfile": "http"
+    },
+    {
+      "name": "Job Search API",
+      "type": "coreclr",
+      "request": "launch",
+      "program": "${workspaceFolder}/services/api/src/Firefly.Signal.JobSearch.Api/bin/Debug/net10.0/Firefly.Signal.JobSearch.Api.dll",
+      "cwd": "${workspaceFolder}/services/api/src/Firefly.Signal.JobSearch.Api",
+      "launchSettingsFilePath": "${workspaceFolder}/services/api/src/Firefly.Signal.JobSearch.Api/Properties/launchSettings.json",
+      "launchSettingsProfile": "http"
+    },
+    {
+      "name": "AI API",
+      "type": "coreclr",
+      "request": "launch",
+      "program": "${workspaceFolder}/services/api/src/Firefly.Signal.Ai.Api/bin/Debug/net10.0/Firefly.Signal.Ai.Api.dll",
+      "cwd": "${workspaceFolder}/services/api/src/Firefly.Signal.Ai.Api",
+      "launchSettingsFilePath": "${workspaceFolder}/services/api/src/Firefly.Signal.Ai.Api/Properties/launchSettings.json",
+      "launchSettingsProfile": "http"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Run Web + APIs (Local Env)",
+      "preLaunchTask": "build-api-solution",
+      "stopAll": true,
+      "configurations": [
+        "Web App (Local Env)",
+        "Gateway API",
+        "Identity API",
+        "Job Search API",
+        "AI API"
+      ]
+    },
+    {
+      "name": "Run ALL APIs",
+      "preLaunchTask": "build-api-solution",
+      "stopAll": true,
+      "configurations": [
+        "Gateway API",
+        "Identity API",
+        "Job Search API",
+        "AI API"
+      ]
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build-api-solution",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "build",
+        "${workspaceFolder}/services/api/Firefly.Signal.Api.slnx"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/services/api"
+      },
+      "problemMatcher": "$msCompile",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,11 +105,11 @@ Issue and branch conventions for backend work:
 
 All issue-driven work follows a three-round pattern. Use the `git-issue` and `git-pr` skills for step-by-step checklists.
 
-- **Round 1 (Kickoff):** Fetch issue → label `in-progress` → create branch → create git worktree at `../firefly-worktrees/<branch>` → enrich issue body → post branch + plan comments.
+- **Round 1 (Kickoff):** Fetch issue → label `in-progress` → create branch → create git worktree at `worktrees/<branch>` → enrich issue body → post branch + plan comments.
 - **Further rounds (Implementation):** Work inside the worktree. Commit and push before ending every chat.
 - **Final round (Ship):** Create PR → squash-merge → switch main repo to `main` → remove worktree → delete local branch.
 
-Git worktrees allow multiple agents to work on the same server and repo concurrently without collision. Each branch gets its own worktree at `../firefly-worktrees/<branch-name>`.
+Git worktrees allow multiple agents to work on the same server and repo concurrently without collision. Each branch gets its own worktree at `worktrees/<branch-name>`.
 
 ## Apps
 


### PR DESCRIPTION
Closes #114

## Summary
- move issue worktree guidance from ../firefly-worktrees to worktrees/<branch> inside the repo
- track the shared VS Code launch and task configuration in the repo
- document that isolated debugging should open the worktree folder directly in VS Code

## Validation
- manual verification of in-repo worktree visibility in VS Code
- manual verification that opening the worktree directly allows launch.json to target that checkout

## Risks / Notes
- nested in-repo worktrees are easy to browse, but developers still need to open the worktree folder itself when they want isolated debug settings